### PR TITLE
Fix the error of dasdfmt

### DIFF
--- a/smtLayer/vmUtils.py
+++ b/smtLayer/vmUtils.py
@@ -360,7 +360,7 @@ def installFS(rh, vaddr, mode, fileSystem, diskType):
             "-y",
             "-b", "4096",
             "-d", "cdl",
-            "-f", device]
+            "-v", device]
         strCmd = ' '.join(cmd)
         rh.printSysLog("Invoking: " + strCmd)
         try:


### PR DESCRIPTION
No '-f' option for dasdfmt.

Signed-off-by: QingFeng Hao <haoqf@linux.vnet.ibm.com>