### PR TITLE
Fix RACF support bug

### DIFF
--- a/zthin-parts/zthin/src/smcli.c
+++ b/zthin-parts/zthin/src/smcli.c
@@ -417,7 +417,7 @@ int main(int argC, char* argV[]) {
     readTraceFile(&vmapiContext);
     TRACE_ENTRY_FLOW(&vmapiContext, TRACEAREA_ZTHIN_GENERAL);
 
-    rc = getSmapiLevel(&vmapiContext, " ", &smapiLevel);
+    rc = getSmapiLevel(&vmapiContext, "", &smapiLevel);
     if (rc != 0){
         printf("\nERROR: Unable to determine SMAPI level.\n");
         return 1;

--- a/zthin-parts/zthin/src/smcliImage.c
+++ b/zthin-parts/zthin/src/smcliImage.c
@@ -369,7 +369,7 @@ int imageCPUDefineDM(int argC, char* argV[], struct _vmApiInternalContext* vmapi
     char strMsg[250];
 
 
-    rc = getSmapiLevel(vmapiContextP, " ", &smapiLevel);
+    rc = getSmapiLevel(vmapiContextP, "", &smapiLevel);
     if (rc != 0){
         printAndLogProcessingErrors("Image_CPU_Define_DM", rc, vmapiContextP, "", 0);
         printf("\nERROR: Unable to determine SMAPI level.\n");

--- a/zthin-parts/zthin/src/smcliImageDefinition.c
+++ b/zthin-parts/zthin/src/smcliImageDefinition.c
@@ -365,7 +365,7 @@ int imageDefinitionQueryDM(int argC, char* argV[], struct _vmApiInternalContext*
     const char * argumentsRequired = "Tk";
     char tempStr[1];
 
-    rc = getSmapiLevel(vmapiContextP, " ", &smapiLevel);
+    rc = getSmapiLevel(vmapiContextP, "", &smapiLevel);
     if (rc != 0){
         printf("\nERROR: Unable to determine SMAPI level.\n");
         return 1;

--- a/zthin-parts/zthin/src/smcliSystem.c
+++ b/zthin-parts/zthin/src/smcliSystem.c
@@ -368,7 +368,7 @@ int systemDiskQuery(int argC, char* argV[], struct _vmApiInternalContext* vmapiC
 
     int smapiLevel = 0;
 
-    rc = getSmapiLevel(vmapiContextP, " ", &smapiLevel);
+    rc = getSmapiLevel(vmapiContextP, "", &smapiLevel);
     if (rc != 0){
         printf("\nERROR: Unable to determine SMAPI level.\n");
         return 1;
@@ -3050,7 +3050,7 @@ int systemWWPNQuery(int argC, char* argV[], struct _vmApiInternalContext* vmapiC
     INIT_MESSAGE_BUFFER(&saveMsgs, MESSAGE_BUFFER_SIZE, msgBuff) ;
 
 
-    rc = getSmapiLevel(vmapiContextP, " ", &smapiLevel);
+    rc = getSmapiLevel(vmapiContextP, "", &smapiLevel);
     if (rc != 0){
         printf("\nERROR: Unable to determine SMAPI level.\n");
         return 1;

--- a/zthin-parts/zthin/src/smcliVirtual.c
+++ b/zthin-parts/zthin/src/smcliVirtual.c
@@ -4099,7 +4099,7 @@ int virtualNetworkVswitchQueryExtended(int argC, char* argV[], struct _vmApiInte
     int native_vlan_id_int;
     int user_vlan_id_int;
 
-    rc = getSmapiLevel(vmapiContextP, " ", &smapiLevel);
+    rc = getSmapiLevel(vmapiContextP, "", &smapiLevel);
     // Options that have arguments are followed by a : character
     while ((option = getopt(argC, argV, "T:k:h?")) != -1)
         switch (option) {


### PR DESCRIPTION
the target ID should be "" instead of " "or it lead to blank image ID usage..