### PR TITLE
Add Code of Conduct ( aligns with OMP standard )

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+All participants agree to abide by the Code of Conduct available at https://github.com/openmainframeproject/tsc/blob/master/CODE_OF_CONDUCT.md.


### PR DESCRIPTION
Signed-off-by: John Mertic <jmertic@linuxfoundation.org>