### PR TITLE
support multipath with multipath FCP devices

### DIFF
--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -421,13 +421,24 @@ user_vlan_id = {
 }
 
 fcp = {
-    'type': ['string'], 'minLength': 4, 'maxLength': 4,
-    'pattern': '^[0-9a-fA-F]{4}$'
+    'type': 'array',
+    'items': {
+        'type': 'string',
+        'minLength': 4,
+        'maxLength': 4,
+        'pattern': '^[0-9a-fA-F]{4}$'
+    }
+
 }
 
 wwpn = {
-    'type': ['string'], 'minLength': 18, 'maxLength': 18,
-    'pattern': '^0x[0-9a-fA-F]{16}$'
+    'type': 'array',
+    'items': {
+        'type': 'string',
+        'minLength': 18,
+        'maxLength': 18,
+        'pattern': '^0x[0-9a-fA-F]{16}$'
+    }
 }
 
 lun = {

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -562,7 +562,8 @@ class SMTClient(object):
         action = "list all guests in database"
         with zvmutils.log_and_reraise_sdkbase_error(action):
             guests_in_db = self._GuestDbOperator.get_guest_list()
-            guests_migrated = self._GuestDbOperator.get_migrated_guest_info_list()
+            guests_migrated = \
+                    self._GuestDbOperator.get_migrated_guest_info_list()
 
         # db query return value in tuple (uuid, userid, metadata, comments)
         userids_in_db = [g[1].upper() for g in guests_in_db]

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
@@ -61,8 +61,8 @@ class HandlersVolumeTest(unittest.TestCase):
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
     def test_volume_attach(self, mock_attach):
         mock_attach.return_value = {'overallRC': 0}
-        connection_info = {"assigner_id": "username", "zvm_fcp": "1fc5",
-                           "target_wwpn": "0x5005076801401234",
+        connection_info = {"assigner_id": "username", "zvm_fcp": ["1fc5"],
+                           "target_wwpn": ["0x5005076801401234"],
                            "target_lun": "0x0026000000000000",
                            "os_version": "rhel7.2",
                            "multipath": "true", "mount_point": ""}
@@ -77,8 +77,8 @@ class HandlersVolumeTest(unittest.TestCase):
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
     def test_volume_detach(self, mock_detach):
         mock_detach.return_value = {'overallRC': 0}
-        connection_info = {"assigner_id": "username", "zvm_fcp": "1fc5",
-                           "target_wwpn": "0x5005076801401234",
+        connection_info = {"assigner_id": "username", "zvm_fcp": ["1fc5"],
+                           "target_wwpn": ["0x5005076801401234"],
                            "target_lun": "0x0026000000000000",
                            "os_version": "rhel7.2",
                            "multipath": "true", "mount_point": ""}

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1167,7 +1167,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         request.assert_any_call(requestData1)
         request.assert_any_call(requestData2)
 
-    @mock.patch.object(database.GuestDbOperator, 'get_migrated_guest_list')
+    @mock.patch.object(database.GuestDbOperator,
+                       'get_migrated_guest_info_list')
     @mock.patch.object(database.GuestDbOperator, 'get_guest_list')
     def test_get_vm_list(self, db_list, migrated_list):
         db_list.return_value = [(u'9a5c9689-d099-46bb-865f-0c01c384f58c',
@@ -1183,7 +1184,8 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         self.assertListEqual(sorted(userid_list),
                              sorted(['TEST0', 'TEST1', 'TEST2']))
 
-    @mock.patch.object(database.GuestDbOperator, 'get_migrated_guest_list')
+    @mock.patch.object(database.GuestDbOperator,
+                       'get_migrated_guest_info_list')
     @mock.patch.object(database.GuestDbOperator, 'get_guest_list')
     def test_get_vm_list_exclude_migrated(self, db_list, migrated_list):
         db_list.return_value = [(u'9a5c9689-d099-46bb-865f-0c01c384f58c',


### PR DESCRIPTION
Now we can attach multipath FCPs to one instance,
But!! we only support multipath, multipath=True is hard coded and
the format of fcp_list configuration should be strict, looks like:
"1111-1115;2111-2115;3111-3115;...."

UT cases were added for those codes.

Signed-off-by: SharpRazor <bjcb@cn.ibm.com>