### PR TITLE
fix bug of capture failure

### DIFF
--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -261,6 +261,28 @@ Console logs might be transferred to sdk user, this option controls how
 large each file can be. A smaller size may mean more calls will be needed
 to transfer large consoles, which may not be desirable for performance reasons.
     '''),
+    Opt('softstop_timeout',
+        section='guest',
+        default=60,
+        opt_type='int',
+        help='''
+The maximum time waiting until the guest shut down.
+
+Sometimes, the shutdown action will take a bit lone time to complete.
+If you want to make sure the guest in shut-down status after executing action
+of softstop, this will help.
+    '''),
+    Opt('softstop_interval',
+        section='guest',
+        default=5,
+        opt_type='int',
+        help='''
+The interval time between 2 retries, in seconds.
+
+This will take effect only when you set softstop_retries item.
+What's more, the value of softstop_timeout/softstop_interval is
+the times retried.
+    '''),
     # monitor options
     Opt('cache_interval',
         section='monitor',

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -386,11 +386,16 @@ class SMTClient(object):
     def guest_softstop(self, userid, **kwargs):
         """Power off VM gracefully, it will call shutdown os then
             deactivate vm"""
-        requestData = "PowerVM " + userid + " softoff"
+        requestData = "PowerVM " + userid + " softoff --wait"
         if 'timeout' in kwargs.keys() and kwargs['timeout']:
             requestData += ' --maxwait ' + str(kwargs['timeout'])
+        else:
+            requestData += ' --maxwait ' + str(CONF.guest.softstop_timeout)
+
         if 'poll_interval' in kwargs.keys() and kwargs['poll_interval']:
             requestData += ' --poll ' + str(kwargs['poll_interval'])
+        else:
+            requestData += ' --poll ' + str(CONF.guest.softstop_interval)
 
         with zvmutils.log_and_reraise_smt_request_failed():
             self._request(requestData)

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -96,7 +96,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
     @mock.patch.object(smtclient.SMTClient, '_request')
     def test_guest_softstop(self, request):
         fake_userid = 'FakeID'
-        requestData = "PowerVM FakeID softoff --maxwait 300 --poll 10"
+        requestData = "PowerVM FakeID softoff --wait --maxwait 300 --poll 10"
         request.return_value = {'overallRC': 0}
         self._smtclient.guest_softstop(fake_userid, timeout=300,
                                         poll_interval=10)


### PR DESCRIPTION
when capturing multiple VMs, zcc may report error like:
The specified source system is currently running

add an option --wait in guest_softstop function
this option will trigger the wait_for_state logic in smtLayer
and the command will wait until the vm is in shutdown status.

Signed-off-by: SharpRazor <bjcb@cn.ibm.com>