### PR TITLE
Fix reboot error of RHCOS created by unpackdiskimage

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -791,13 +791,17 @@ function deployDiskImage {
 
     blsfile=$(ls /tmp/$userID/boot_partition/loader/entries/*.conf)
     #Get zipl config file for parameters
-    echo "$(grep options $blsfile | cut -d' ' -f2-) rd.dasd=0.0.$channelID rd.znet=qeth,$nicID,layer2=1,portno=0 ignition.firstboot rd.neednet=1 ip=dhcp" > /tmp/zipl_prm
+    echo "$(grep options $blsfile | cut -d' ' -f2-) rd.dasd=0.0.$channelID rd.znet=qeth,$nicID,layer2=1,portno=0 ignition.firstboot rd.neednet=1 ip=dhcp" > /tmp/$userID/zipl_prm
     #Run zipl to update bootloader
-    zipl --verbose -p /tmp/zipl_prm -i $(ls /tmp/$userID/boot_partition/ostree/*/*vmlinuz*) -r $(ls /tmp/$userID/boot_partition/ostree/*/*initramfs*) --target /tmp/$userID/boot_partition
+    zipl --verbose -p /tmp/$userID/zipl_prm -i $(ls /tmp/$userID/boot_partition/ostree/*/*vmlinuz*) -r $(ls /tmp/$userID/boot_partition/ostree/*/*initramfs*) --target /tmp/$userID/boot_partition
     if [[ $? -ne 0 ]]; then
         printError "failed updating bootloder"
         exit 1
     fi
+    #Update BLS config file for reboot
+    sed -e '/options/d' $blsfile > /tmp/$userID/blsfile
+    echo "options $(cat /tmp/$userID/zipl_prm) " >>/tmp/$userID/blsfile
+    cat /tmp/$userID/blsfile > $blsfile
   } #update_zipl_bootloader{}
 
   function deployFBAptImage {
@@ -997,14 +1001,13 @@ function deployDiskImage {
     wipefs --all --force "${DEST_DEV}"
 
     #low-level format the ECKD DASD using dasdfmt, if needed
+    inform "Format ${DEST_DEV} and Copy..."
+    type lszdev >/dev/null 2>&1 || { printError "Require lszdev tool, but not installed. Aborting."; exit 3; }
     DEST_DEV_BUS=$(lszdev --by-node ${DEST_DEV} | tail -n 1  | awk '{print $2}')
-    if [[ $? -ne 0 ]]; then
-            log "failed to lszdev DASD device"
-            exit 1
-    fi
     if [ "$(< /sys/bus/ccw/devices/${DEST_DEV_BUS}/status)" = "unformatted" ]; then
         dasdfmt --blocksize 4096 --disk_layout cdl --mode full -ypv "${DEST_DEV}"
     fi
+
     #Get blocks for per track of target disk
     block_per_tracks=$(fdasd -p ${DEST_DEV} | grep blocks\ per\ track | awk '{print $5}')
     #the first 2 tracks of the ECKD DASD are reserved


### PR DESCRIPTION
The new deployed RHCOS vm reboot failed because the zipl bootloader is updated during the initramfs boot process.

This commit is to fix the error by updating the BootLoaderSpec file to have the target zipl parameters.

Signed-off-by: XiaoMeiZheng <xmzheng@cn.ibm.com>