### PR TITLE
Bugfix: fdasd fails to re-read the partition when resizing the dasd.

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -361,8 +361,18 @@ function resizeECKD {
     out=`fdasd -a ${devNode}`
     rc=$?
     if (( rc != 0 )); then
-      printError "When resizing the dasd, 'fsdasd -a' to  ${devNode} returns rc: $rc, out: $out"
-      return 1
+      if (( rc == 255 )); then
+        sleep 0.5
+        out =`blockdev --rereadpt ${devNode}`
+        rc=$?
+        if (( rc != 0 )); then
+          printError "When resizing the dasd, 'blockdev --rereadpt' to  ${devNode} returns rc: $rc, out: $out"
+          return 1
+        fi
+      else
+        printError "When resizing the dasd, 'fsdasd -a' to  ${devNode} returns rc: $rc, out: $out"
+        return 1
+      fi
     fi
   fi
 


### PR DESCRIPTION
when resizing the dasd, the "fdasd -a" fails to re-read the partition
table with the BLKRRPART IOCTL error(rc:255). It is most likely due to
the device just being in use by udev. So use blockdev to trigger
a re-read of the partition table.

Signed-off-by: Xiao Feng Ren <renxiaof@linux.vnet.ibm.com>