### PR TITLE
Bugfix: fdasd fails to re-read the partition when resizing the dasd.

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -336,8 +336,18 @@ function resizeECKD {
     out=`fdasd -a ${devNode}`
     rc=$?
     if (( rc != 0 )); then
-      printError "When resizing the dasd, 'fsdasd -a' to  ${devNode} returns rc: $rc, out: $out"
-      return 1
+      if (( rc == 255 )); then
+        sleep 0.5
+        out =`blockdev --rereadpt ${devNode}`
+        rc=$?
+        if (( rc != 0 )); then
+          printError "When resizing the dasd, 'blockdev --rereadpt' to  ${devNode} returns rc: $rc, out: $out"
+          return 1
+        fi
+      else
+        printError "When resizing the dasd, 'fsdasd -a' to  ${devNode} returns rc: $rc, out: $out"
+        return 1
+      fi
     fi
   fi
 


### PR DESCRIPTION
when resizing the dasd, the "fdasd -a" fails to re-read the partition
table with the BLKRRPART IOCTL error(rc:255). Since the fdasd has already
created the partition and updated the VTOC to the disk, so re-read the
partition table to read the device information.

Signed-off-by: Xiao Feng Ren <renxiaof@linux.vnet.ibm.com>