### PR TITLE
Fix vswitch_revoker_user error

### DIFF
--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1022,7 +1022,6 @@ class SDKAPI(object):
 
         self._networkops.grant_user_to_vswitch(vswitch_name, userid)
 
-    @check_guest_exist(check_index=1)
     def vswitch_revoke_user(self, vswitch_name, userid):
         """Revoke user for vswitch
 


### PR DESCRIPTION
When neutron-zvm-agent try to unbind port and revoke
user from vswitch, it calls vswitch_revoke_user in
zvmsdk api.py. Before this method there is a decrator
check_guest_exist to check the userid in db. If the
userid has been deleted from db, vswitch_revoker_user
would fail with error:Guest XXXX does not exist.

This commit is to fix the error by deleting the decrator
because vswitch_revoke_user doesn't require guest exist.

Signed-off-by: Shu Juan Zhang <zshujuan@cn.ibm.com>