### PR TITLE
Add guest_deregister in zCC for unmanaging VM

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -429,6 +429,12 @@ guest_register_net_set:
   in: body
   required: true
   type: string
+action_deregister_guest:
+  description: |
+    Take ``deregister_vm`` action on guest.
+  in: body
+  required: true
+  type: string
 action_live_resize_cpus_of_guest:
   description: |
     Take ``live_resize_cpus`` action on guest.

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -898,6 +898,30 @@ Register guest to be managed by z/VM Cloud Connector.
 
 * Response contents:
 
+Guest deregister
+--------------
+
+**POST /guests/{userid}/action**
+
+Deregister guest to be managed by z/VM Cloud Connector.
+
+* Request:
+
+.. restapi_parameters:: parameters.yaml
+
+  - userid: guest_userid
+  - action: action_deregister_guest
+
+* Request sample:
+
+.. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_guest_deregister.tpl
+   :language: javascript
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
 
 Live resize CPUs of guest
 -------------------------

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -245,6 +245,12 @@ def req_guest_pre_migrate(start_index, *args, **kwargs):
     return url, body
 
 
+def req_guest_deregister(start_index, *args, **kwargs):
+    url = '/guests/%s/action'
+    body = {'action': 'deregister_vm'}
+    return url, body
+
+
 def req_guest_live_resize_cpus(start_index, *args, **kwargs):
     url = '/guests/%s/action'
     body = {'action': 'live_resize_cpus',
@@ -600,6 +606,11 @@ DATABASE = {
         'args_required': 3,
         'params_path': 1,
         'request': req_guest_pre_migrate},
+    'guest_deregister': {
+        'method': 'POST',
+        'args_required': 1,
+        'params_path': 1,
+        'request': req_guest_deregister},
     'guest_live_migrate': {
         'method': 'POST',
         'args_required': 5,

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -471,6 +471,27 @@ class SDKAPI(object):
                                 userid, interface, switch)
             LOG.info("Guest %s registered." % userid)
 
+    # Deregister the guest (not delete), this function has no relationship with
+    # migration.
+    def guest_deregister(self, userid):
+        """DB operation for deregister vm for offboard (dismiss) request.
+        :param userid: (str) the userid of the vm to be deregistered
+        """
+        userid = userid.upper()
+        if not zvmutils.check_userid_exist(userid):
+            LOG.error("User directory '%s' does not exist." % userid)
+            raise exception.SDKObjectNotExistError(
+                    obj_desc=("Guest '%s'" % userid), modID='guest')
+        else:
+            action = "delete switches of guest '%s' from database" % userid
+            with zvmutils.log_and_reraise_sdkbase_error(action):
+                self._NetworkDbOperator.switch_delete_record_for_userid(userid)
+
+            action = "delete guest '%s' from database" % userid
+            with zvmutils.log_and_reraise_sdkbase_error(action):
+                self._GuestDbOperator.delete_guest_by_userid(userid)
+            LOG.info("Guest %s deregistered." % userid)
+
     @check_guest_exist()
     def guest_live_migrate(self, userid, dest_zcc_userid, destination,
                            parms, lgr_action):

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -282,6 +282,11 @@ class VMAction(object):
                                 userid, meta, net_set)
         return info
 
+    @validation.schema(guest.deregister_vm)
+    def deregister_vm(self, userid, body):
+        info = self.client.send_request('guest_deregister', userid)
+        return info
+
     @validation.schema(guest.live_migrate_vm)
     def live_migrate_vm(self, userid, body):
         # dest_zcc_userid default as ''

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -250,6 +250,14 @@ register_vm = {
     'additionalProperties': False
 }
 
+deregister_vm = {
+    'type': 'object',
+    'properties': {
+        'userid': parameter_types.userid,
+    },
+    'additionalProperties': False
+}
+
 userid_list_array_query = {
     'type': 'object',
     'properties': {

--- a/zvmsdk/tests/fvt/api_templates/test_guest_deregister.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_guest_deregister.tpl
@@ -1,0 +1,3 @@
+{
+   "action": "deregister_vm",
+}

--- a/zvmsdk/tests/fvt/test_utils.py
+++ b/zvmsdk/tests/fvt/test_utils.py
@@ -364,6 +364,11 @@ class TestzCCClient(object):
         body = json.dumps(body)
         return self._guest_action(userid, body)
 
+    def guest_deregister(self, userid):
+        body = {"action": "deregister_vm"}
+        body = json.dumps(body)
+        return self._guest_action(userid, body)
+
     def guest_live_migrate_vm(self, userid, dest_zcc_userid,
                          destination, parms, operation):
         body = {"action": "live_migrate_vm",

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
@@ -106,6 +106,17 @@ class GuestActionsTest(SDKWSGITest):
 
     @mock.patch.object(util, 'wsgi_path_item')
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
+    def test_guest_deregister(self, mock_action,
+                        mock_userid):
+        self.req.body = '{"action": "deregister_vm"}'
+        mock_action.return_value = ''
+        mock_userid.return_value = FAKE_USERID
+
+        guest.guest_action(self.req)
+        mock_action.assert_called_once_with('guest_deregister', FAKE_USERID)
+
+    @mock.patch.object(util, 'wsgi_path_item')
+    @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
     def test_guest_softstop_with_timeout_poll_interval(self, mock_action,
                                                        mock_userid):
         self.req.body = """{"action": "softstop", "timeout": 300,

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -276,3 +276,12 @@ class SDKAPITestCase(base.SDKTestCase):
                            'assigner_id': 'user1'}
         self.api.volume_detach(connection_info)
         mock_detach.assert_called_once_with(connection_info)
+
+    @mock.patch("zvmsdk.database.NetworkDbOperator.switch_delete_record_for_userid")
+    @mock.patch("zvmsdk.database.GuestDbOperator.delete_guest_by_userid")
+    def test_guest_deregister(self, guestdb_del, networkdb_del):
+        guestdb_del.return_value = ''
+        networkdb_del.return_value = ''
+        self.api.guest_deregister(self.userid)
+        guestdb_del.assert_called_once_with(self.userid)
+        networkdb_del.assert_called_once_with(self.userid)


### PR DESCRIPTION
The VM still exists after deregistered, but its record is
removed from zCC. This is typically used by user to dismiss/offboard
a VM when he doesn't want to manage it through zCC.

nova virt zvm driver should call this API to unmanage a VM with userid,
e.g. in hypervisor.py and driver.py.

Signed-off-by: QingFeng Hao <haoqf@linux.vnet.ibm.com>