### PR TITLE
[1.5.n] Provide the VM onboarding function in guest_register API

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -435,7 +435,7 @@ action_register_guest:
   type: string
 guest_register_meta:
   description: |
-    The metadata of the vm to be relocated.
+    The metadata of the vm to be registered.
   in: body
   required: true
   type: string
@@ -446,6 +446,12 @@ guest_register_net_set:
   in: body
   required: true
   type: string
+guest_register_port_macs:
+  description: |
+    The dict of virtual interface port id and mac id
+  in: body
+  required: false
+  type: dict
 action_deregister_guest:
   description: |
     Take ``deregister_vm`` action on guest.

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -888,6 +888,7 @@ Register guest to be managed by z/VM Cloud Connector.
   - action: action_register_guest
   - meta: guest_register_meta
   - net_set: guest_register_net_set  
+  - port: guest_register_port_macs
 
 * Request sample:
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -237,11 +237,13 @@ def req_guest_live_migrate(start_index, *args, **kwargs):
     return url, body
 
 
-def req_guest_pre_migrate(start_index, *args, **kwargs):
+def req_guest_register(start_index, *args, **kwargs):
     url = '/guests/%s/action'
     body = {'action': 'register_vm',
             'meta': args[start_index],
             'net_set': args[start_index + 1]}
+    if len(args) - start_index == 3:
+        body['port_macs'] = args[start_index + 2]
     return url, body
 
 
@@ -604,8 +606,9 @@ DATABASE = {
     'guest_register': {
         'method': 'POST',
         'args_required': 3,
+        'args_optional': 1,
         'params_path': 1,
-        'request': req_guest_pre_migrate},
+        'request': req_guest_register},
     'guest_deregister': {
         'method': 'POST',
         'args_required': 1,
@@ -834,10 +837,13 @@ class RESTClient(object):
             raise APINameNotFound(msg)
         # check args count is valid
         count = DATABASE[api_name]['args_required']
+        optional = 0
+        if 'args_optional' in DATABASE[api_name].keys():
+            optional = DATABASE[api_name]['args_optional']
         if len(args) < count:
             msg = "Missing some args,please check:%s." % args
             raise ArgsFormatError(msg)
-        if len(args) > count:
+        if len(args) > count + optional:
             msg = "Too many args,please check:%s." % args
             raise ArgsFormatError(msg)
 

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -434,47 +434,125 @@ class SDKAPI(object):
         with zvmutils.log_and_reraise_sdkbase_error(action):
             return self._vmops.get_definition_info(userid, **kwargs)
 
-    def guest_register(self, userid, meta, net_set):
-        """DB operation for migrate vm from another z/VM host in same SSI
+    """Parse the nics' info from the user directory
+    :param user_direct: (str) the user directory info to be parsed
+    """
+    def _parse_nic_info(self, user_direct):
+        nics_info = {}
+        for nic_info in user_direct:
+            if nic_info.startswith('NICDEF'):
+                split_info = nic_info.split()
+                nic_id = split_info[1].strip()
+                count = 2
+                one_nic = nics_info.get(nic_id, {})
+                while count < len(split_info):
+                    if split_info[count] == 'LAN':
+                        one_nic['vswitch'] = split_info[count + 2].strip()
+                        count += 3
+                        continue
+                    elif split_info[count] == 'MACID':
+                        one_nic['mac'] = split_info[count + 1].strip()
+                        count += 2
+                        continue
+                    elif split_info[count] == 'VLAN':
+                        one_nic['vid'] = split_info[count + 1].strip()
+                        count += 2
+                        continue
+                    else:
+                        count += 1
+
+                nics_info[nic_id] = one_nic
+
+        return nics_info
+
+    def guest_register(self, userid, meta, net_set, port_macs=None):
+        """Register vm by inserting or updating DB for e.g. migration and onboarding
         :param userid: (str) the userid of the vm to be relocated or tested
         :param meta: (str) the metadata of the vm to be relocated or tested
         :param net_set: (str) the net_set of the vm, default is 1.
+        :param port_macs: (dir) the virtual interface port id maps with mac id
+                     Format: { macid1 : portid1, macid2 : portid2}.
+                     For example,
+                     {
+                       'EF5091':'6e2ecc4f-14a2-4f33-9f12-5ac4a42f97e7',
+                       '69FCF1':'389dee5e-7b03-405c-b1e8-7c9c235d1425'
+                     }
         """
+        if port_macs is not None and not isinstance(port_macs, dict):
+            msg = ('Invalid input parameter port_macs, expect dict')
+            LOG.error(msg)
+            raise exception.SDKInvalidInputFormat(msg)
+
         userid = userid.upper()
         if not zvmutils.check_userid_exist(userid):
             LOG.error("User directory '%s' does not exist." % userid)
             raise exception.SDKObjectNotExistError(
                     obj_desc=("Guest '%s'" % userid), modID='guest')
         else:
-            action = "list all guests in database which has been migrated."
+            action = "query the guest in database."
             with zvmutils.log_and_reraise_sdkbase_error(action):
-                guests = self._GuestDbOperator.get_migrated_guest_list()
-            if userid in str(guests):
-                """change comments for vm"""
-                comments = self._GuestDbOperator.get_comments_by_userid(
+                guest = self._GuestDbOperator.get_guest_by_userid(userid)
+            if guest is not None:
+                # The below handling is for migration
+                action = "list all guests in database which has been migrated."
+                with zvmutils.log_and_reraise_sdkbase_error(action):
+                    guests = self._GuestDbOperator.get_migrated_guest_list()
+                if userid in str(guests):
+                    """change comments for vm"""
+                    comments = self._GuestDbOperator.get_comments_by_userid(
                                                                     userid)
-                comments['migrated'] = 0
-                action = "update guest '%s' in database" % userid
-                with zvmutils.log_and_reraise_sdkbase_error(action):
-                    self._GuestDbOperator.update_guest_by_userid(userid,
+                    comments['migrated'] = 0
+                    action = "update guest '%s' in database" % userid
+                    with zvmutils.log_and_reraise_sdkbase_error(action):
+                        self._GuestDbOperator.update_guest_by_userid(userid,
                                                     comments=comments)
-            else:
-                """add one record for new vm"""
-                action = "add guest '%s' to database" % userid
-                with zvmutils.log_and_reraise_sdkbase_error(action):
-                    self._GuestDbOperator.add_guest_migrated(userid, meta,
+                    LOG.info("Guest %s comments updated." % userid)
+                # We just return no matter onboarding or migration
+                # since the guest exists
+                return
+
+            # add one record for new vm for both onboarding and migration,
+            # and even others later.
+            action = "add guest '%s' to database" % userid
+            with zvmutils.log_and_reraise_sdkbase_error(action):
+                self._GuestDbOperator.add_guest_registered(userid, meta,
                                                              net_set)
-                action = "add switches of guest '%s' to database" % userid
-                info = self._vmops.get_definition_info(userid)
-                user_direct = info['user_direct']
-                for nic_info in user_direct:
-                    if nic_info.startswith('NICDEF'):
-                        nic_list = nic_info.split()
-                        interface = nic_list[1]
-                        switch = nic_list[6]
-                        with zvmutils.log_and_reraise_sdkbase_error(action):
-                            self._NetworkDbOperator.switch_add_record_migrated(
-                                userid, interface, switch)
+
+            # We need to query and add vswitch to the database.
+            # The result got by get_definition_info is like:
+            # USER ZSJC002F LBYONLY 4096m 64G G
+            # INCLUDE ZCCDFLT
+            # COMMAND DEF STOR RESERVED 61440M
+            # CPU 00 BASE
+            # IPL 0100
+            # LOGONBY IAASADM
+            # MACHINE ESA 32
+            # NICDEF 1000 TYPE QDIO LAN SYSTEM VSC1159B DEVICES 3 MACID EF5091
+            # NICDEF 1000 VLAN 8
+            # NICDEF 1003 TYPE QDIO LAN SYSTEM VSC1159B DEVICES 3 MACID 69FCF1
+            # NICDEF 1003 VLAN 798
+            # MDISK 0100 3390 0001 14564 IAS10D MR
+            action = "add switches of guest '%s' to database" % userid
+            info = self._vmops.get_definition_info(userid)
+            user_direct = info['user_direct']
+            nics_info = self._parse_nic_info(user_direct)
+            for key in nics_info:
+                interface = key
+                switch = nics_info[key]['vswitch']
+                port = None
+                if port_macs is not None:
+                    if 'mac' in nics_info[key].keys():
+                        mac = nics_info[key]['mac']
+                        if mac in port_macs.keys():
+                            port = port_macs[mac]
+                    if port is None:
+                        LOG.warning("Port not found for nic %s, %s." %
+                                    (key, port_macs))
+                    else:
+                        LOG.info("Port found for nic %s." % key)
+                with zvmutils.log_and_reraise_sdkbase_error(action):
+                    self._NetworkDbOperator.switch_add_record(
+                                userid, interface, port, switch)
             LOG.info("Guest %s registered." % userid)
 
     # Deregister the guest (not delete), this function has no relationship with

--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -604,9 +604,9 @@ class GuestDbOperator(object):
                                                        modID=self._module_id)
         return guest
 
-    def add_guest_migrated(self, userid, meta, net_set,
+    def add_guest_registered(self, userid, meta, net_set,
                              comments=None):
-        # Add guest which is migrated from other host.
+        # Add guest which is migrated from other host or onboarded.
         guest_id = str(uuid.uuid4())
         with get_guest_conn() as conn:
             conn.execute(

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -282,8 +282,11 @@ class VMAction(object):
     def register_vm(self, userid, body):
         meta = body['meta']
         net_set = body['net_set']
+        port_macs = None
+        if 'port_macs' in body.keys():
+            port_macs = body['port_macs']
         info = self.client.send_request('guest_register',
-                                userid, meta, net_set)
+                                userid, meta, net_set, port_macs)
         return info
 
     @validation.schema(guest.deregister_vm)

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -248,9 +248,10 @@ register_vm = {
     'properties': {
         'meta': {'type': ['string']},
         'net_set': {'type': ['string']},
+        'port': {'type': ['string']},
     },
     'required': ['meta', 'net_set'],
-    'additionalProperties': False
+    'additionalProperties': True
 }
 
 deregister_vm = {

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
@@ -106,6 +106,38 @@ class GuestActionsTest(SDKWSGITest):
 
     @mock.patch.object(util, 'wsgi_path_item')
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
+    def test_guest_register(self, mock_action,
+                        mock_userid):
+        self.req.body = '{"action": "register_vm",\
+                          "meta": "rhel7",\
+                          "net_set": "1",\
+                          "port_macs": "5abc7819-abec-4deb-9115-2af5da249155"}'
+        mock_action.return_value = ''
+        mock_userid.return_value = FAKE_USERID
+        guest.guest_action(self.req)
+        mock_action.assert_called_once_with('guest_register', FAKE_USERID,
+                                            "rhel7",
+                                            "1",
+                                            "5abc7819-abec-4deb"
+                                            "-9115-2af5da249155")
+
+    @mock.patch.object(util, 'wsgi_path_item')
+    @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
+    def test_guest_register_no_port_macs(self, mock_action,
+                        mock_userid):
+        self.req.body = '{"action": "register_vm",\
+                          "meta": "rhel7",\
+                          "net_set": "1"}'
+        mock_action.return_value = ''
+        mock_userid.return_value = FAKE_USERID
+        guest.guest_action(self.req)
+        mock_action.assert_called_once_with('guest_register', FAKE_USERID,
+                                            "rhel7",
+                                            "1",
+                                            None)
+
+    @mock.patch.object(util, 'wsgi_path_item')
+    @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
     def test_guest_deregister(self, mock_action,
                         mock_userid):
         self.req.body = '{"action": "deregister_vm"}'

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -278,6 +278,142 @@ class SDKAPITestCase(base.SDKTestCase):
         self.api.volume_detach(connection_info)
         mock_detach.assert_called_once_with(connection_info)
 
+    @mock.patch("zvmsdk.utils.check_userid_exist")
+    @mock.patch("zvmsdk.vmops.VMOps.get_definition_info")
+    @mock.patch("zvmsdk.database.GuestDbOperator.add_guest_registered")
+    @mock.patch("zvmsdk.database.NetworkDbOperator.switch_add_record")
+    def test_guest_register(self, networkdb_add, guestdb_reg,
+                              get_def_info, chk_usr):
+        networkdb_add.return_value = ''
+        guestdb_reg.return_value = ''
+        info = {}
+        info['user_direct'] = ['USER FBA LBYONLY 2048m 64G G',
+                               'INCLUDE ZCCDFLT', 'COMMAND DEF STOR '
+                               'RESERVED 57344M',
+                               'CPU 00 BASE', 'CPU 01', 'CPU 02',
+                               'CPU 03', 'IPL 0100',
+                               'LOGONBY IAASADM', 'MACHINE ESA 32',
+                               'NICDEF 1000 TYPE QDIO LAN SYSTEM VSC11590 '
+                               'DEVICES 3 MACID EF5091',
+                               'NICDEF 1000 VLAN 8',
+                               '']
+        get_def_info.return_value = info
+        chk_usr.return_value = True
+
+        meta_data = 'rhel7'
+        net_set = '1'
+        port_macs = {'EF5091': '6e2ecc4f-14a2-4f33-9f12-5ac4a42f97e7',
+                     '69FCF1': '389dee5e-7b03-405c-b1e8-7c9c235d1425'
+                    }
+
+        self.api.guest_register(self.userid, meta_data, net_set, port_macs)
+        networkdb_add.assert_called_once_with(self.userid, '1000',
+                                              '6e2ecc4f-14a2-4f33-9f12'
+                                              '-5ac4a42f97e7',
+                                              'VSC11590')
+        guestdb_reg.assert_called_once_with(self.userid, 'rhel7', '1')
+        get_def_info.assert_called_once_with(self.userid)
+        chk_usr.assert_called_once_with(self.userid)
+
+    @mock.patch("zvmsdk.utils.check_userid_exist")
+    @mock.patch("zvmsdk.vmops.VMOps.get_definition_info")
+    @mock.patch("zvmsdk.database.GuestDbOperator.add_guest_registered")
+    @mock.patch("zvmsdk.database.NetworkDbOperator.switch_add_record")
+    def test_guest_register_invalid_portmacs(self, networkdb_add, guestdb_reg,
+                              get_def_info, chk_usr):
+        networkdb_add.return_value = ''
+        guestdb_reg.return_value = ''
+        info = {}
+        info['user_direct'] = ['USER FBA LBYONLY 2048m 64G G',
+                               'INCLUDE ZCCDFLT',
+                               'COMMAND DEF STOR RESERVED 57344M',
+                               'CPU 00 BASE', 'CPU 01', 'CPU 02',
+                               'CPU 03', 'IPL 0100',
+                               'LOGONBY IAASADM', 'MACHINE ESA 32',
+                               'NICDEF 1000 TYPE QDIO LAN SYSTEM VSC11590 '
+                               'DEVICES 3 MACID EF5091',
+                               'NICDEF 1000 VLAN 8',
+                               '']
+        get_def_info.return_value = info
+        chk_usr.return_value = True
+
+        meta_data = 'rhel7'
+        net_set = '1'
+        port_macs = '6e2ecc4f-14a2-4f33-9f12-5ac4a42f97e7'
+
+        self.assertRaises(exception.SDKInvalidInputFormat,
+                          self.api.guest_register,
+                          self.userid, meta_data, net_set, port_macs)
+
+    @mock.patch("zvmsdk.utils.check_userid_exist")
+    @mock.patch("zvmsdk.vmops.VMOps.get_definition_info")
+    @mock.patch("zvmsdk.database.GuestDbOperator.add_guest_registered")
+    @mock.patch("zvmsdk.database.NetworkDbOperator.switch_add_record")
+    def test_guest_register_no_port_macs(self, networkdb_add, guestdb_reg,
+                              get_def_info, chk_usr):
+        networkdb_add.return_value = ''
+        guestdb_reg.return_value = ''
+        info = {}
+        info['user_direct'] = ['USER FBA LBYONLY 2048m 64G G',
+                               'INCLUDE ZCCDFLT', 'COMMAND DEF STOR '
+                               'RESERVED 57344M',
+                               'CPU 00 BASE', 'CPU 01', 'CPU 02',
+                               'CPU 03', 'IPL 0100',
+                               'LOGONBY IAASADM', 'MACHINE ESA 32',
+                               'NICDEF 1000 TYPE QDIO LAN SYSTEM VSC11590 '
+                               'DEVICES 3 MACID EF5091',
+                               'NICDEF 1000 VLAN 8',
+                               '']
+        get_def_info.return_value = info
+        chk_usr.return_value = True
+
+        meta_data = 'rhel7'
+        net_set = '1'
+
+        self.api.guest_register(self.userid, meta_data, net_set)
+        networkdb_add.assert_called_once_with(self.userid, '1000',
+                                              None,
+                                              'VSC11590')
+        guestdb_reg.assert_called_once_with(self.userid, 'rhel7', '1')
+        get_def_info.assert_called_once_with(self.userid)
+        chk_usr.assert_called_once_with(self.userid)
+
+    @mock.patch("zvmsdk.utils.check_userid_exist")
+    @mock.patch("zvmsdk.vmops.VMOps.get_definition_info")
+    @mock.patch("zvmsdk.database.GuestDbOperator.add_guest_registered")
+    @mock.patch("zvmsdk.database.NetworkDbOperator.switch_add_record")
+    @mock.patch("zvmsdk.database.GuestDbOperator.update_guest_by_userid")
+    @mock.patch("zvmsdk.database.GuestDbOperator.get_comments_by_userid")
+    @mock.patch("zvmsdk.database.GuestDbOperator.get_migrated_guest_list")
+    @mock.patch("zvmsdk.database.GuestDbOperator.get_guest_by_userid")
+    def test_guest_register_guest_in_db(self, get_guest, get_mig_guest,
+                              get_comments, update_guest, networkdb_add,
+                              guestdb_reg, get_def_info, chk_usr):
+        get_guest.return_value = 'fake_guest'
+        get_mig_guest.return_value = self.userid + ' other info'
+        get_comments.return_value = {'migrated': 1}
+        update_guest.return_value = ''
+        # Below mocks shall not be called
+        networkdb_add.return_value = ''
+        guestdb_reg.return_value = ''
+        get_def_info.return_value = {}
+        chk_usr.return_value = True
+
+        meta_data = 'rhel7'
+        net_set = '1'
+
+        self.api.guest_register(self.userid, meta_data, net_set)
+        get_guest.assert_called_once_with(self.userid)
+        get_mig_guest.assert_called_once_with()
+        get_comments.assert_called_once_with(self.userid)
+        update_guest.assert_called_once_with(self.userid,
+                                             comments={'migrated': 0})
+        chk_usr.assert_called_once_with(self.userid)
+
+        networkdb_add.assert_not_called()
+        guestdb_reg.assert_not_called()
+        get_def_info.assert_not_called()
+
     @mock.patch("zvmsdk.database.NetworkDbOperator."
                 "switch_delete_record_for_userid")
     @mock.patch("zvmsdk.database.GuestDbOperator.delete_guest_by_userid")

--- a/zvmsdk/tests/unit/test_database.py
+++ b/zvmsdk/tests/unit/test_database.py
@@ -524,11 +524,11 @@ class GuestDbOperatorTestCase(base.SDKTestCase):
         self.db_op.delete_guest_by_id('ad8f352e-4c9e-4335-aafa-4f4eb2fcc77c')
 
     @mock.patch.object(uuid, 'uuid4')
-    def test_add_guest_migrated(self, get_uuid):
+    def test_add_guest_registered(self, get_uuid):
         meta = 'fakemeta=1, fakemeta2=True'
         net = 1
         get_uuid.return_value = u'ad8f352e-4c9e-4335-aafa-4f4eb2fcc77c'
-        self.db_op.add_guest_migrated(self.userid, meta, net)
+        self.db_op.add_guest_registered(self.userid, meta, net)
         # Query, the guest should in table
         guests = self.db_op.get_guest_list()
         self.assertEqual(1, len(guests))


### PR DESCRIPTION
The current guest_register API in zCC is originated live migration actually and
it can't fulfill the requirement of onboarding although it intends to.
This PR is to retrofit it to be a general API which can fulfill both migration and onboarding's
requirement, and even future requirements as well.

This PR is for 1.5.n branch and the related PRs are https://github.com/openmainframeproject/python-zvm-sdk/pull/76 and https://github.com/openmainframeproject/python-zvm-sdk/pull/128
