### PR TITLE
CoreOS fixed IP and hostname support

### DIFF
--- a/zvmsdk/dist.py
+++ b/zvmsdk/dist.py
@@ -36,7 +36,7 @@ class LinuxDist(object):
 
     Due to we need to interact with linux dist and inject different files
     according to the dist version. Currently RHEL6, RHEL7, SLES11, SLES12
-    and UBUNTU16 are supported.
+    , UBUNTU16 and RHCOS4 are supported.
     """
     def __init__(self):
         self._smtclient = smtclient.get_smtclient()
@@ -962,6 +962,151 @@ class rhel8(rhel7):
                              self._get_all_device_filename())
         return '\nrm -f %s\n' % files
         
+
+class rhcos(LinuxDist):
+    def create_coreos_parameter(self, network_info, userid):
+        # Create the coreos parameters for ZCC, includes ignitionUrl, diskType,
+        # nicID and ipConfig, then save them in a temp file
+        try:
+            vif = network_info[0]
+            ip_addr = vif['ip_addr']
+            gateway_addr = vif['gateway_addr']
+            netmask = vif['cidr'].split("/")[-1]
+            nic_name = "enc" + vif['nic_vdev']
+            # update dns name server info if they're defined in subnet
+            _dns = ["", ""]
+            if 'dns_addr' in vif.keys():
+                if ((vif['dns_addr'] is not None) and
+                    (len(vif['dns_addr']) > 0)):
+                    _index = 0
+                    for dns in vif['dns_addr']:
+                        _dns[_index] = dns
+                        _index += 1
+            # transfor network info and hostname into form of
+            # ip=<client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>
+            # :<interface>:none[:[<dns1>][:<dns2>]]
+            result = "%s::%s:%s:%s:%s:none:%s:%s" %(ip_addr, gateway_addr, 
+                                                    netmask, userid, nic_name,
+                                                    _dns[0], _dns[1])
+            tmp_path = self._smtclient.get_guest_path(userid.upper())
+            LOG.debug("Created coreos fixed ip parameter: %(result)s, "
+                      "writing them to tempfile: %(tmp_path)s/fixed_ip_param"
+                      % {'result': result, 'tmp_path': tmp_path})
+            with open('%s/fixed_ip_param' % tmp_path, 'w') as f:
+                f.write(result)
+                f.write('\n')
+            return True
+        except Exception as err:
+            LOG.error("Failed to create coreos parameter for userid '%s',"
+                      "error: %s" % (userid, err))
+            return False
+        
+    def read_coreos_parameter(self, userid):
+        # read coreos fixed ip parameters from tempfile by matching userid
+        tmp_path = self._smtclient.get_guest_path(userid.upper())
+        tmp_file_path = ('%s/fixed_ip_param' % tmp_path)
+        with open(tmp_file_path, 'r') as f:
+            fixed_ip_parameter = f.read().replace('\n','')
+            LOG.debug('Read coreos fixed ip paramter: %(parameter)s '
+                      'from tempfile: %(filename)s'
+                      % {'parameter': fixed_ip_parameter,
+                      'filename': tmp_file_path})
+        # Clean up tempfile
+        self._smtclient.clean_temp_folder(tmp_path)
+        return fixed_ip_parameter
+    
+    def _append_udev_info(self, cmd_str, cfg_files, file_name_route,
+                      route_cfg_str, udev_cfg_str, first=False):
+        pass
+    
+    def _append_udev_rules_file(self, cfg_files, base_vdev):
+        pass
+
+    def _config_to_persistent(self):
+        """rhcos"""
+        pass
+
+    def _delete_vdev_info(self, vdev):
+        pass
+
+    def _delete_zfcp_config_records(self, fcp, target_lun):
+        pass
+
+    def _enable_network_interface(self, device, ip, broadcast):
+        pass
+
+    def _get_cfg_str(self, device, broadcast_v4, gateway_v4, ip_v4,
+                     netmask_v4, address_read, subchannels):
+        pass
+
+    def _get_clean_command(self):
+        pass
+
+    def _get_cmd_str(self, address_read, address_write, address_data):
+        pass
+
+    def _get_device_filename(self, vdev):
+        pass
+    
+    def _get_device_name(self, vdev):
+        pass
+
+    def _get_dns_filename(self):
+        pass
+
+    def _get_network_file_path(self):
+        pass
+
+    def _get_route_str(self, gateway_v4):
+        pass
+
+    def _get_source_devices(self, fcp, target_lun):
+        pass
+
+    def _get_udev_configuration(self, device, dev_channel):
+        pass
+
+    def _get_udev_rules(self, channel_read, channel_write, channel_data):
+        pass
+
+    def _offline_fcp_device(self, fcp):
+        pass
+
+    def _online_fcp_device(self, fcp):
+        pass
+
+    def _rescan_multipath(self):
+        pass
+
+    def _restart_multipath(self):
+        pass
+
+    def _set_sysfs(self, fcp, target_wwpns, target_lun):
+        pass
+
+    def _set_zfcp_config_files(self, fcp, target_lun):
+        pass
+
+    def _set_zfcp_multipath(self, new):
+        pass
+
+    def create_active_net_interf_cmd(self):
+        pass
+
+    def get_scp_string(self, root, fcp, wwpn, lun):
+        pass
+
+    def get_zipl_script_lines(self, image, ramdisk, root, fcp, wwpn, lun):
+        pass
+
+    def get_znetconfig_contents(self):
+        pass
+
+
+class rhcos4(rhcos):
+    pass
+
+    
 class sles(LinuxDist):
     def _get_network_file_path(self):
         return '/etc/sysconfig/network/'
@@ -1652,7 +1797,8 @@ class LinuxDistManager(object):
     def _parse_release(self, os_version, distro, remain):
         supported = {'rhel': ['6', '7', '8'],
                      'sles': ['11', '12'],
-                     'ubuntu': ['16']}
+                     'ubuntu': ['16'],
+                     'rhcos': ['4']}
         releases = supported[distro]
 
         for r in releases:
@@ -1670,7 +1816,8 @@ class LinuxDistManager(object):
         """
         supported = {'rhel': ['rhel', 'redhat', 'red hat'],
                     'sles': ['suse', 'sles'],
-                    'ubuntu': ['ubuntu']}
+                    'ubuntu': ['ubuntu'],
+                    'rhcos': ['rhcos', 'coreos', 'red hat coreos']}
         os_version = os_version.lower()
         for distro, patterns in supported.items():
             for i in patterns:

--- a/zvmsdk/networkops.py
+++ b/zvmsdk/networkops.py
@@ -1,4 +1,4 @@
-# Copyright 2017,2018 IBM Corp.
+# Copyright 2017,2020 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -103,33 +103,37 @@ class NetworkOPS(object):
 
     def network_configuration(self, userid, os_version, network_info,
                               active=False):
-        network_file_path = self._smtclient.get_guest_temp_path(userid)
-        LOG.debug('Creating folder %s to contain network configuration files'
-                  % network_file_path)
-        # check whether network interface has already been set for the guest
-        # if not, means this the first time to set the network interface
-        first = self._smtclient.is_first_network_config(userid)
-        (network_doscript, active_cmds) = self._generate_network_doscript(
-                                                           userid,
-                                                           os_version,
-                                                           network_info,
-                                                           network_file_path,
-                                                           first,
-                                                           active=active)
-        fileClass = "X"
-        try:
-            self._smtclient.punch_file(userid, network_doscript, fileClass)
-        finally:
-            LOG.debug('Removing the folder %s ', network_file_path)
-            shutil.rmtree(network_file_path)
+        if os_version.lower().startswith('rhcos'):
+            linuxdist = self._dist_manager.get_linux_dist(os_version)()
+            linuxdist.create_coreos_parameter(network_info, userid)
+        else: 
+            network_file_path = self._smtclient.get_guest_temp_path(userid)
+            LOG.debug('Creating folder %s to contain network configuration files'
+                      % network_file_path)
+            # check whether network interface has already been set for the guest
+            # if not, means this the first time to set the network interface
+            first = self._smtclient.is_first_network_config(userid)
+            (network_doscript, active_cmds) = self._generate_network_doscript(
+                                                               userid,
+                                                               os_version,
+                                                               network_info,
+                                                               network_file_path,
+                                                               first,
+                                                               active=active)
+            fileClass = "X"
+            try:
+                self._smtclient.punch_file(userid, network_doscript, fileClass)
+            finally:
+                LOG.debug('Removing the folder %s ', network_file_path)
+                shutil.rmtree(network_file_path)
 
-        # update guest db to mark the network is already set
-        if first:
-            self._smtclient.update_guestdb_with_net_set(userid)
+            # update guest db to mark the network is already set
+            if first:
+                self._smtclient.update_guestdb_with_net_set(userid)
 
-        # using zvmguestconfigure tool to parse network_doscript
-        if active:
-            self._smtclient.execute_cmd(userid, active_cmds)
+            # using zvmguestconfigure tool to parse network_doscript
+            if active:
+                self._smtclient.execute_cmd(userid, active_cmds)
 
     # Prepare and create network doscript for instance
     def _generate_network_doscript(self, userid, os_version, network_info,

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -1,4 +1,4 @@
-# Copyright 2017,2018 IBM Corp.
+# Copyright 2017,2020 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -165,6 +165,8 @@ errors = {
                11: ("Failed to live resize memory of guest: '%(userid)s', "
                    "error: define standby memory failed with "
                    "smt error: '%(err)s'."),
+               12: ("Failed to deploy image to userid: '%(userid)s', "
+                   "get unpackdiskimage cmd failed: %(err)s"),
               },
               "Operation on Guest failed"
               ],

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -353,6 +353,8 @@ disk_conf = {
 # For ubuntu linux, it will match ubuntuX, ubuntuX.Y, ubuntuX.Y.Z,
 # where X is 16, Y is 01 to 10, Z is 0 to 9, such as ubuntu16.04.3,
 # all case insensitive
+# For red hat cores linux, it will match rhcosX, where X is 4, 
+# such as rhcos4, all case insensitive
 os_version = {
 'oneOf': [
 {'type': 'string',
@@ -369,7 +371,10 @@ os_version = {
  '^((s|S)(u|U)(s|S)(e|E))(11|12){1}(([.]|((s|S)(p|P)))[0-9])?$'},
 {'type': 'string',
  'pattern':
- '^((u|U)(b|B)(u|U)(n|N)(t|T)(u|U))(16){1}([.][0-9]{2})?([.][0-9])?$'}
+ '^((u|U)(b|B)(u|U)(n|N)(t|T)(u|U))(16){1}([.][0-9]{2})?([.][0-9])?$'},
+ {'type': 'string',
+ 'pattern':
+ '^((r|R)(h|H)(c|C)(o|O)(s|S))(4){1}?$'}
 ]
 }
 
@@ -531,6 +536,9 @@ max_mem = {
     }
 
 hostname = {
-    'type': 'string', 'minLength': 1, 'maxLength': 255,
-    'pattern': '^[a-zA-Z0-9-._]*$',
+    'oneOf': [
+        {'type': 'null'},
+        {'type': 'string', 'minLength': 1, 'maxLength': 255, 
+        'pattern': '^[a-zA-Z0-9-._]*$',}
+    ]
 }

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -1,4 +1,4 @@
-# Copyright 2017,2018 IBM Corp.
+# Copyright 2017,2020 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -115,6 +115,12 @@ class SMTClient(object):
     def get_guest_temp_path(self, userid):
         return self._pathutils.get_guest_temp_path(userid)
 
+    def get_guest_path(self, userid):
+        return self._pathutils.get_guest_path(userid)    
+    
+    def clean_temp_folder(self, tmp_folder):
+        return self._pathutils.clean_temp_folder(tmp_folder)
+
     def _generate_vdev(self, base, offset):
         """Generate virtual device number based on base vdev
         :param base: base virtual device number, string of 4 bit hex.
@@ -122,6 +128,19 @@ class SMTClient(object):
         """
         vdev = hex(int(base, 16) + offset)[2:]
         return vdev.rjust(4, '0')
+
+    def _generate_increasing_nic_id(self, nic_id):
+        """Generate increasing nic id string
+        :param nic_id: hexadecimal nic id like '1000'
+        :return: increasing nic id, string like '0.0.1000,0.0.1001,0.0.1002'
+        """
+        nic_id = str(hex(int(nic_id, 16)))[2:]
+        nic_id_1 = str(hex(int(nic_id, 16)+1))[2:]
+        nic_id_2 = str(hex(int(nic_id, 16)+2))[2:]
+        if len(nic_id_2) > 4:
+            errmsg = ("Virtual device number %s is not valid" % nic_id_2)
+            raise exception.SDKInvalidInputFormat(msg=errmsg)
+        return "0.0.%s,0.0.%s,0.0.%s" % (nic_id, nic_id_1, nic_id_2)
 
     def generate_disk_vdev(self, start_vdev=None, offset=0):
         """Generate virtual device number for disks
@@ -710,6 +729,71 @@ class SMTClient(object):
                                   'vdev': vdev})
         LOG.info(msg)
 
+    def guest_deploy_rhcos(self, userid, image_name, transportfiles,
+                           remotehost=None, vdev=None, hostname=None):
+        """ Deploy image and punch config driver to target """
+        # (TODO: add the support of multiple disks deploy)
+        msg = ('Start to deploy image %(img)s to guest %(vm)s'
+                % {'img': image_name, 'vm': userid})
+        LOG.info(msg)
+        image_file = '/'.join([self._get_image_path_by_name(image_name),
+                               CONF.zvm.user_root_vdev])
+        # Unpack image file to root disk
+        vdev = vdev or CONF.zvm.user_root_vdev
+        tmp_trans_dir = None
+        
+        if remotehost:
+            # download igintion file from remote host
+            tmp_trans_dir = tempfile.mkdtemp()
+            local_trans = '/'.join([tmp_trans_dir,
+                                    os.path.basename(transportfiles)])
+            cmd = ["/usr/bin/scp", "-B",
+                   "-P", CONF.zvm.remotehost_sshd_port,
+                   "-o StrictHostKeyChecking=no",
+                   ("%s:%s" % (remotehost, transportfiles)),
+                   local_trans]
+            with zvmutils.expect_and_reraise_internal_error(modID='guest'):
+                (rc, output) = zvmutils.execute(cmd)
+            if rc != 0:
+                err_msg = ('copy ignition file with command %(cmd)s '
+                           'failed with output: %(res)s' %
+                           {'cmd': str(cmd), 'res': output})
+                LOG.error(err_msg)
+                raise exception.SDKGuestOperationError(rs=4, userid=userid,
+                                                       err_info=err_msg)
+            transportfiles = local_trans
+
+        cmd = self._get_unpackdiskimage_cmd_rhcos(userid, image_name, 
+                                                  transportfiles, vdev, 
+                                                  image_file, hostname)
+        with zvmutils.expect_and_reraise_internal_error(modID='guest'):
+            (rc, output) = zvmutils.execute(cmd)
+        if rc != 0:
+            err_msg = ("unpackdiskimage failed with return code: %d." % rc)
+            err_output = ""
+            output_lines = output.split('\n')
+            for line in output_lines:
+                if line.__contains__("ERROR:"):
+                    err_output += ("\\n" + line.strip())
+            LOG.error(err_msg + err_output)
+            raise exception.SDKGuestOperationError(rs=3, userid=userid,
+                                                   unpack_rc=rc,
+                                                   err=err_output)
+
+        # remove the temp ignition file
+        if tmp_trans_dir:
+            self._pathutils.clean_temp_folder(tmp_trans_dir) 
+
+        # Update os version in guest metadata
+        # TODO: may should append to old metadata, not replace
+        metadata = 'os_version=%s' % self.image_get_os_distro(image_name)
+        self._GuestDbOperator.update_guest_by_userid(userid, meta=metadata)
+
+        msg = ('Deploy image %(img)s to guest %(vm)s disk %(vdev)s'
+               ' successfully' % {'img': image_name, 'vm': userid,
+                                  'vdev': vdev})
+        LOG.info(msg)
+
     def guest_capture(self, userid, image_name, capture_type='rootonly',
                       compress_level=6):
         if capture_type == "alldisks":
@@ -941,6 +1025,44 @@ class SMTClient(object):
             # For sysclone, parse the user directory entry to get the devices
             # for capture, leave for future
             pass
+
+    def _get_unpackdiskimage_cmd_rhcos(self, userid, image_name, transportfiles=None,
+                                       vdev=None, image_file=None, hostname=None):
+        os_version = self.image_get_os_distro(image_name)
+        # Query image disk type 
+        image_disk_type = self._get_image_disk_type(image_name)
+        if image_disk_type == None:
+            err_msg = ("failed to get image disk type for "
+                       "image '%(image_name)s'."
+                        % {'image_name': image_name}) 
+            raise exception.SDKGuestOperationError(rs=12, userid=userid,
+                                               err=err_msg)
+        try:
+            # Query vm's disk pool type and image disk type 
+            from zvmsdk import dist
+            _dist_manager = dist.LinuxDistManager()
+            linuxdist = _dist_manager.get_linux_dist(os_version)()
+            # Read coros fixed ip parameter from tempfile
+            fixed_ip_parameter = linuxdist.read_coreos_parameter(userid)
+        except Exception as err:
+            err_msg = ("failed to read coreos fixed ip"
+                        "parameters for userid '%(userid)s'," 
+                        "error: %(err)s." 
+                        % {'userid': userid, 'err': err})
+            raise exception.SDKGuestOperationError(rs=12, userid=userid,
+                                               err=err_msg)
+        if fixed_ip_parameter == None: 
+            err_msg = ("coreos fixed ip parameters don't exist.")
+            raise exception.SDKGuestOperationError(rs=12, userid=userid,
+                                               err=err_msg)
+        if hostname != None:
+            # replace hostname to display name instead of userid
+            fixed_ip_parameter = fixed_ip_parameter.replace(userid.upper(), hostname)
+        # read nic device id and change it into the form like "0.0.1000,0.0.1001,0.0.1002" 
+        nic_id = self._generate_increasing_nic_id(
+            fixed_ip_parameter.split(":")[5].replace("enc",""))
+        return ['sudo', '/opt/zthin/bin/unpackdiskimage', userid, vdev,
+               image_file, transportfiles, image_disk_type, nic_id, fixed_ip_parameter]
 
     def grant_user_to_vswitch(self, vswitch_name, userid):
         """Set vswitch to grant user."""
@@ -2128,6 +2250,33 @@ class SMTClient(object):
             raise exception.SDKImageOperationError(rs=20, img=image_name)
         disk_size_units = image_info[0]['disk_size_units'].split(':')[0]
         return disk_size_units
+
+    def image_get_os_distro(self, image_name):
+        """
+        Return the operating system distro of the specified image
+        """
+        image_info = self.image_query(image_name)
+        if not image_info:
+            raise exception.SDKImageOperationError(rs=20, img=image_name)
+        os_distro = image_info[0]['imageosdistro']
+        return os_distro
+    
+    def _get_image_disk_type(self, image_name):
+        """
+        Return image disk type
+        """
+        image_info = self.image_query(image_name)
+        if ((image_info[0]['comments'] is not None) and
+            (image_info[0]['comments'].__contains__('disk_type'))):
+            image_disk_type = eval(image_info[0]['comments'])['disk_type']
+            if image_disk_type == 'DASD':
+                return 'ECKD'
+            elif image_disk_type == 'SCSI':
+                return 'SCSI'
+            else:
+                return None
+        else:
+            return None
 
     def punch_file(self, userid, fn, fclass):
         rd = ("changevm %(uid)s punchfile %(file)s --class %(class)s" %

--- a/zvmsdk/tests/unit/test_dist.py
+++ b/zvmsdk/tests/unit/test_dist.py
@@ -14,6 +14,7 @@
 import mock
 
 from zvmsdk import dist
+from zvmsdk import utils as zvmutil
 from zvmsdk.tests.unit import base
 
 
@@ -501,6 +502,18 @@ class RHEL8TestCase(base.SDKTestCase):
         self.assertEqual('DNS1="9.0.2.1"', cfg_str[11])
         self.assertEqual('DNS2="9.0.3.1"', cfg_str[12])
 
+class RHCOS4TestCase(base.SDKTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(RHCOS4TestCase, cls).setUpClass()
+        cls.os_version = 'rhcos4'
+
+    def setUp(self):
+        super(RHCOS4TestCase, self).setUp()
+        self.dist_manager = dist.LinuxDistManager()
+        self.linux_dist = self.dist_manager.get_linux_dist(self.os_version)()
+    
 class SLESTestCase(base.SDKTestCase):
 
     @classmethod

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1,4 +1,4 @@
-# Copyright 2017,2018 IBM Corp.
+# Copyright 2017,2020 IBM Corp.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -21,6 +21,7 @@ from smtLayer import smt
 
 from zvmsdk import config
 from zvmsdk import database
+from zvmsdk import dist
 from zvmsdk import exception
 from zvmsdk import smtclient
 from zvmsdk import utils as zvmutils
@@ -324,41 +325,6 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         guestauth.assert_called_once_with(userid)
         guest_update.assert_called_once_with(userid, meta='os_version=fakeos')
 
-    @mock.patch.object(zvmutils, 'execute')
-    @mock.patch.object(smtclient.SMTClient, '_request')
-    @mock.patch.object(smtclient.SMTClient, '_get_image_path_by_name')
-    def test_guest_deploy_unpackdiskimage_failed(self, get_image_path,
-                                                 request, execute):
-        base.set_conf("zvm", "user_root_vdev", "0100")
-        userid = 'fakeuser'
-        image_name = 'fakeimg'
-        transportfiles = '/faketran'
-        get_image_path.return_value = \
-            '/var/lib/zvmsdk/images/netboot/rhel7/fakeimg'
-        unpack_error = ('unpackdiskimage fakeuser start time: '
-                        '2017-08-16-01:29:59.453\nSOURCE USER ID: "fakeuser"\n'
-                        'DISK CHANNEL:   "0100"\n'
-                        'IMAGE FILE:     "/var/lib/zvmsdk/images/fakeimg"\n\n'
-                        'Image file compression level: 6\n'
-                        'Deploying image to fakeuser\'s disk at channel 100.\n'
-                        'ERROR: Unable to link fakeuser 0100 disk. '
-                        'HCPLNM053E FAKEUSER not in CP directory\n'
-                        'HCPDTV040E Device 260C does not exist\n'
-                        'ERROR: Failed to connect disk: fakeuser:0100\n\n'
-                        'IMAGE DEPLOYMENT FAILED.\n'
-                        'A detailed trace can be found at: /var/log/zthin/'
-                        'unpackdiskimage_trace_2017-08-16-01:29:59.453.txt\n'
-                        'unpackdiskimage end time: 2017-08-16-01:29:59.605\n')
-        execute.return_value = (3, unpack_error)
-        self.assertRaises(exception.SDKGuestOperationError,
-                           self._smtclient.guest_deploy, userid, image_name,
-                           transportfiles)
-        get_image_path.assert_called_once_with(image_name)
-        unpack_cmd = ['sudo', '/opt/zthin/bin/unpackdiskimage', 'fakeuser',
-                      '0100',
-                     '/var/lib/zvmsdk/images/netboot/rhel7/fakeimg/0100']
-        execute.assert_called_once_with(unpack_cmd)
-
     @mock.patch.object(zvmutils.PathUtils, 'clean_temp_folder')
     @mock.patch.object(tempfile, 'mkdtemp')
     @mock.patch.object(zvmutils, 'execute')
@@ -429,6 +395,50 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         request.assert_has_calls([mock.call(purge_rd), mock.call(punch_rd)])
         mkdtemp.assert_called_with()
         cleantemp.assert_called_with('/tmp/tmpdir')
+    
+    @mock.patch.object(smtclient.SMTClient, 'image_query')
+    def test_image_get_os_distro(self, image_info):
+        image_info.return_value = [{'image_size_in_bytes': '3072327680', 
+                                    'disk_size_units': '3339:CYL', 
+                                    'md5sum': '370cd177c51e39f0e2e2beecbb88f701', 
+                                    'comments': "{'disk_type':'DASD'}", 
+                                    'imagename': '0b3013e1-1356-431c-b680-ba06a1768aea', 
+                                    'imageosdistro': 'RHCOS4', 
+                                    'type': 'rootonly'}]
+        self.assertEqual(self._smtclient.image_get_os_distro(image_info), 'RHCOS4')
+
+    @mock.patch.object(smtclient.SMTClient, 'image_query')
+    def test_get_image_disk_type_dasd(self, image_info):
+        image_info.return_value = [{'image_size_in_bytes': '3072327680', 
+                                    'disk_size_units': '3339:CYL', 
+                                    'md5sum': '370cd177c51e39f0e2e2beecbb88f701', 
+                                    'comments': "{'disk_type':'DASD'}", 
+                                    'imagename': '0b3013e1-1356-431c-b680-ba06a1768aea', 
+                                    'imageosdistro': 'RHCOS4', 
+                                    'type': 'rootonly'}]
+        self.assertEqual(self._smtclient._get_image_disk_type(image_info), 'ECKD')
+
+    @mock.patch.object(smtclient.SMTClient, 'image_query')
+    def test_get_image_disk_type_scsi(self, image_info):
+        image_info.return_value = [{'image_size_in_bytes': '3072327680', 
+                                    'disk_size_units': '3339:CYL', 
+                                    'md5sum': '370cd177c51e39f0e2e2beecbb88f701', 
+                                    'comments': "{'disk_type':'SCSI'}", 
+                                    'imagename': '0b3013e1-1356-431c-b680-ba06a1768aea', 
+                                    'imageosdistro': 'RHCOS4', 
+                                    'type': 'rootonly'}]
+        self.assertEqual(self._smtclient._get_image_disk_type(image_info), 'SCSI')
+
+    @mock.patch.object(smtclient.SMTClient, 'image_query')
+    def test_get_image_disk_type_failed(self, image_info):
+        image_info.return_value = [{'image_size_in_bytes': '3072327680', 
+                                    'disk_size_units': '3339:CYL', 
+                                    'md5sum': '370cd177c51e39f0e2e2beecbb88f701', 
+                                    'comments': "{'disk_type':'FBA'}", 
+                                    'imagename': '0b3013e1-1356-431c-b680-ba06a1768aea', 
+                                    'imageosdistro': 'RHCOS4', 
+                                    'type': 'rootonly'}]
+        self.assertEqual(self._smtclient._get_image_disk_type(image_info), None)
 
     @mock.patch.object(zvmutils, 'get_smt_userid')
     @mock.patch.object(smtclient.SMTClient, '_request')
@@ -1382,6 +1392,16 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         idx = 1
         vdev = self._smtclient._generate_vdev(base, idx)
         self.assertEqual(vdev, '0101')
+
+    def test_generate_generate_increasing_nic_id(self):
+        nic_id_base = "1000"
+        nic_id = self._smtclient._generate_increasing_nic_id(nic_id_base)
+        self.assertEqual(nic_id, '0.0.1000,0.0.1001,0.0.1002')
+
+    def test_generate_generate_increasing_nic_id_failed(self):
+        self.assertRaises(exception.SDKInvalidInputFormat, 
+                          self._smtclient._generate_increasing_nic_id,
+                          'FFFF')
 
     @mock.patch.object(smtclient.SMTClient, '_add_mdisk')
     def test_add_mdisks(self, add_mdisk):


### PR DESCRIPTION
Dhcp can't be used in CoreOS, so a parameter(in form of ip=<client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:none[:[<dns1>][:<dns2>]]) are used to tell
unpackdiskimage/dracut create a CoreOS vm with fixed ip and hostname
instead of using "ip=dhcp".

Refer to http://man7.org/linux/man-pages/man7/dracut.cmdline.7.html