### PR TITLE
Dev/onboarding add APIs for host get guest definition info

### DIFF
--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -1289,6 +1289,34 @@ Get disk pool information on the host.
 .. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_host_disk_info.tpl
    :language: javascript
 
+Get Guest definition info
+-------------------------
+
+**GET /host/{userid}/def_info**
+
+Get the user direct of the given userid from hypervisor.
+
+* Request:
+
+.. restapi_parameters:: parameters.yaml
+
+  - userid: guest_userid
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
+.. restapi_parameters:: parameters.yaml
+
+  - output: user_direct_guest
+
+* Response sample:
+
+.. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_host_get_guest_definition_info.tpl
+   :language: javascript
+
 Image(s)
 ========
 

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -1205,7 +1205,33 @@ Delete Guest nic
 Host
 ====
 
-Get info from host (hypervisor) running on.
+Get guests list, info from host (hypervisor) running on.
+
+Get Guests List
+---------------
+
+**GET /host/guests**
+
+List names of all the guests on the host.
+
+* Request:
+
+  None
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
+.. restapi_parameters:: parameters.yaml
+
+  - output: guest_list
+
+* Response sample:
+
+.. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_host_get_guest_list.tpl
+   :language: javascript
 
 Get Host Info
 -------------

--- a/smtLayer/getVM.py
+++ b/smtLayer/getVM.py
@@ -34,6 +34,7 @@ Each subfunction contains a list that has:
 subfuncHandler = {
     'CONSOLEOUTPUT': ['getConsole', lambda rh: getConsole(rh)],
     'DIRECTORY': ['getDirectory', lambda rh: getDirectory(rh)],
+    'ALLDIRECTORY': ['getAllDirectory', lambda rh: getAllDirectory(rh)],
     'HELP': ['help', lambda rh: help(rh)],
     'ISREACHABLE': ['checkIsReachable', lambda rh: checkIsReachable(rh)],
     'STATUS': ['getStatus', lambda rh: getStatus(rh)],
@@ -310,6 +311,34 @@ def getDirectory(rh):
         rh.updateResults(results)    # Use results from invokeSMCLI
 
     rh.printSysLog("Exit getVM.getDirectory, rc: " +
+                   str(rh.results['overallRC']))
+    return rh.results['overallRC']
+
+
+def getAllDirectory(rh):
+    """
+    Get a list of defined virtual images.
+    Input:
+       Request Handle with the following properties:
+          function    - 'CMDVM'
+          subfunction - 'CMD'
+    Output:
+       Request Handle updated with the results.
+       Return code - 0: ok, non-zero: error
+    """
+    rh.printSysLog("Enter getVM.getAllDirectory")
+
+    parms = []
+    results = invokeSMCLI(rh, "Image_Name_Query_DM", parms)
+    if results['overallRC'] == 0:
+        results['response'] = re.sub('\*DVHOPT.*', '', results['response'])
+        rh.printLn("N", results['response'])
+    else:
+        # SMAPI API failed.
+        rh.printLn("ES", results['response'])
+        rh.updateResults(results)    # Use results from invokeSMCLI
+
+    rh.printSysLog("Exit getVM.getAllDirectory, rc: " +
                    str(rh.results['overallRC']))
     return rh.results['overallRC']
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -389,6 +389,12 @@ def req_host_get_info(start_index, *args, **kwargs):
     return url, body
 
 
+def req_host_get_guest_list(start_index, *args, **kwargs):
+    url = '/host/guests'
+    body = None
+    return url, body
+
+
 def req_host_diskpool_get_info(start_index, *args, **kwargs):
     url = '/host/diskpool'
     poolname = kwargs.get('disk_pool', None)
@@ -710,6 +716,11 @@ DATABASE = {
         'args_required': 0,
         'params_path': 0,
         'request': req_host_get_info},
+    'host_get_guest_list': {
+        'method': 'GET',
+        'args_required': 0,
+        'params_path': 0,
+        'request': req_host_get_guest_list},
     'host_diskpool_get_info': {
         'method': 'GET',
         'args_required': 0,

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -406,6 +406,12 @@ def req_host_diskpool_get_info(start_index, *args, **kwargs):
     return url, body
 
 
+def req_host_get_guest_definition_info(start_index, *args, **kwargs):
+    url = '/host/%s/def_info'
+    body = None
+    return url, body
+
+
 def req_image_import(start_index, *args, **kwargs):
     url = '/images'
     body = {'image': {'image_name': args[start_index],
@@ -726,6 +732,11 @@ DATABASE = {
         'args_required': 0,
         'params_path': 0,
         'request': req_host_diskpool_get_info},
+    'host_get_guest_definition_info': {
+        'method': 'GET',
+        'args_required': 1,
+        'params_path': 1,
+        'request': req_host_get_guest_definition_info},
     'image_import': {
         'method': 'POST',
         'args_required': 3,

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -254,6 +254,23 @@ class SDKAPI(object):
         with zvmutils.log_and_reraise_sdkbase_error(action):
             return self._hostops.diskpool_get_info(diskpool_name)
 
+    def host_get_guest_definition_info(self, userid, **kwargs):
+        """Get definition info for the specified guest vm on hypervisor,
+        also could be used to check specific info.
+
+        :param str userid: the user id of the guest vm
+        :param dict kwargs: Dictionary used to check specific info in user
+                            direct. Valid keywords for kwargs:
+                            nic_coupled=<vdev>, where <vdev> is the virtual
+                            device number of the nic to be checked the couple
+                            status.
+        :returns: Dictionary describing user direct and check info result
+        :rtype: dict
+        """
+        action = "get the definition info of guest '%s' on hypervisor" % userid
+        with zvmutils.log_and_reraise_sdkbase_error(action):
+            return self._hostops.get_guest_definition_info(userid, **kwargs)
+
     def image_delete(self, image_name):
         """Delete image from image repository
 

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -217,6 +217,14 @@ class SDKAPI(object):
         with zvmutils.log_and_reraise_sdkbase_error(action):
             return self._hostops.get_info()
 
+    def host_get_guest_list(self):
+        """list names of all the VMs on the host.
+        :returns: names of the vm on this hypervisor, in a list.
+        """
+        action = "list guests on the host"
+        with zvmutils.log_and_reraise_sdkbase_error(action):
+            return self._hostops.guest_list()
+
     def host_diskpool_get_info(self, disk_pool=None):
         """ Retrieve diskpool information.
         :param str disk_pool: the disk pool info. It use ':' to separate

--- a/zvmsdk/hostops.py
+++ b/zvmsdk/hostops.py
@@ -96,3 +96,24 @@ class HOSTOps(object):
                     raise exception.SDKInternalError(msg=errmsg)
 
         return dp_info
+
+    def get_guest_definition_info(self, userid, **kwargs):
+        check_command = ["nic_coupled"]
+        direct_info = self._smtclient.get_user_direct(userid)
+        info = {}
+        info['user_direct'] = direct_info
+
+        for k, v in kwargs.items():
+            if k in check_command:
+                if (k == 'nic_coupled'):
+                    info['nic_coupled'] = False
+                    nstr = "NICDEF %s TYPE QDIO LAN SYSTEM" % v
+                    for inf in direct_info:
+                        if nstr in inf:
+                            info['nic_coupled'] = True
+                            break
+            else:
+                raise exception.SDKInvalidInputFormat(
+                    msg=("invalid check option for user direct: %s") % k)
+
+        return info

--- a/zvmsdk/hostops.py
+++ b/zvmsdk/hostops.py
@@ -66,6 +66,11 @@ class HOSTOps(object):
 
         return host_info
 
+    def guest_list(self):
+        guest_list = self._smtclient.get_all_user_direct()
+        with zvmutils.expect_invalid_resp_data(guest_list):
+            return guest_list
+
     def diskpool_get_info(self, pool):
         dp_info = self._smtclient.get_diskpool_info(pool)
         with zvmutils.expect_invalid_resp_data(dp_info):

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -89,6 +89,9 @@ ROUTE_LIST = (
     ('/host', {
         'GET': host.host_get_info,
     }),
+    ('/host/guests', {
+        'GET': host.host_get_guest_list,
+    }),
     ('/host/diskpool', {
         'GET': host.host_get_disk_info,
     }),

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -95,6 +95,9 @@ ROUTE_LIST = (
     ('/host/diskpool', {
         'GET': host.host_get_disk_info,
     }),
+    ('/host/{userid}/def_info', {
+        'GET': host.host_get_guest_definition_info,
+    }),
     ('/images', {
         'POST': image.image_create,
         'GET': image.image_query

--- a/zvmsdk/sdkwsgi/handlers/host.py
+++ b/zvmsdk/sdkwsgi/handlers/host.py
@@ -42,6 +42,10 @@ class HostAction(object):
         info = self.client.send_request('host_get_info')
         return info
 
+    def get_guest_list(self):
+        info = self.client.send_request('host_get_guest_list')
+        return info
+
     @validation.query_schema(image.diskpool)
     def diskpool_get_info(self, req, poolname):
         info = self.client.send_request('host_diskpool_get_info',
@@ -71,6 +75,21 @@ def host_get_info(req):
     req.response.content_type = 'application/json'
     return req.response
 
+
+@util.SdkWsgify
+@tokens.validate
+def host_get_guest_list(req):
+
+    def _host_get_guest_list():
+        action = get_action()
+        return action.get_guest_list()
+
+    info = _host_get_guest_list()
+    info_json = json.dumps(info)
+    req.response.body = utils.to_utf8(info_json)
+    req.response.content_type = 'application/json'
+    req.response.status = util.get_http_code_from_sdk_return(info)
+    return req.response
 
 @util.SdkWsgify
 @tokens.validate

--- a/zvmsdk/sdkwsgi/handlers/host.py
+++ b/zvmsdk/sdkwsgi/handlers/host.py
@@ -23,6 +23,7 @@ from zvmsdk.sdkwsgi.handlers import tokens
 from zvmsdk.sdkwsgi import util
 from zvmsdk import utils
 from zvmsdk.sdkwsgi import validation
+from zvmsdk.sdkwsgi.schemas import host
 from zvmsdk.sdkwsgi.schemas import image
 
 
@@ -50,6 +51,11 @@ class HostAction(object):
     def diskpool_get_info(self, req, poolname):
         info = self.client.send_request('host_diskpool_get_info',
                                         disk_pool=poolname)
+        return info
+
+    @validation.query_schema(host.userid_list_query)
+    def get_guest_definition_info(self, req, userid):
+        info = self.client.send_request('host_get_guest_definition_info', userid)
         return info
 
 
@@ -103,6 +109,24 @@ def host_get_disk_info(req):
     if 'poolname' in req.GET:
         poolname = req.GET['poolname']
     info = _host_get_disk_info(req, poolname)
+    info_json = json.dumps(info)
+    req.response.status = util.get_http_code_from_sdk_return(info,
+        additional_handler=util.handle_not_found)
+    req.response.body = utils.to_utf8(info_json)
+    req.response.content_type = 'application/json'
+    return req.response
+
+@util.SdkWsgify
+@tokens.validate
+def host_get_guest_definition_info(req):
+
+    def _host_get_guest_definition_info(req, userid):
+        action = get_action()
+        return action.get_guest_definition_info(req, userid)
+
+    userid = util.wsgi_path_item(req.environ, 'userid')
+    info = _host_get_guest_definition_info(req, userid)
+
     info_json = json.dumps(info)
     req.response.status = util.get_http_code_from_sdk_return(info,
         additional_handler=util.handle_not_found)

--- a/zvmsdk/sdkwsgi/schemas/host.py
+++ b/zvmsdk/sdkwsgi/schemas/host.py
@@ -1,0 +1,23 @@
+# Copyright 2020 IBM Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from zvmsdk.sdkwsgi.validation import parameter_types
+
+userid_list_query = {
+    'type': 'object',
+    'properties': {
+        'userid': parameter_types.userid_list,
+    },
+    'additionalProperties': False
+}

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -1407,6 +1407,11 @@ class SMTClient(object):
             results = self._request("getvm %s directory" % userid)
         return results.get('response', [])
 
+    def get_all_user_direct(self):
+        with zvmutils.log_and_reraise_smt_request_failed():
+            results = self._request("getvm alldirectory")
+        return results.get('response', [])
+
     def _delete_nic_active_exception(self, error, userid, vdev):
         if ((error.results['rc'] == 204) and (error.results['rs'] == 28)):
             errmsg = error.format_message()

--- a/zvmsdk/tests/fvt/api_templates/test_host_get_guest_list.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_host_get_guest_list.tpl
@@ -1,0 +1,8 @@
+{
+    "rs": 0,
+    "overallRC": 0,
+    "modID": null,
+    "rc": 0,
+    "errmsg": "",
+    "output": ["v1", "v2"]
+}

--- a/zvmsdk/tests/fvt/test_host.py
+++ b/zvmsdk/tests/fvt/test_host.py
@@ -21,6 +21,11 @@ CONF = config.CONF
 
 class HostTestCase(base.ZVMConnectorBaseTestCase):
 
+    def test_host_get_guest_list(self):
+        resp = self.client.api_request(url='/host/guests')
+        self.assertEqual(200, resp.status_code)
+        self.apibase.verify_result('test_host_get_guest_list', resp.content)
+
     def test_host_info(self):
         resp = self.client.api_request(url='/host')
         self.assertEqual(200, resp.status_code)

--- a/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
+++ b/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
@@ -607,6 +607,22 @@ class RESTClientTestCase(unittest.TestCase):
 
     @mock.patch.object(requests, 'request')
     @mock.patch('zvmconnector.restclient.RESTClient._get_token')
+    def test_host_get_guest_list(self, get_token, request):
+        method = 'GET'
+        url = '/host/guests'
+        body = None
+        header = self.headers
+        full_uri = self.base_url + url
+        request.return_value = self.response
+        get_token.return_value = self._tmp_token()
+
+        self.client.call("host_get_guest_list")
+        request.assert_called_with(method, full_uri,
+                                   data=body, headers=header,
+                                   verify=False)
+
+    @mock.patch.object(requests, 'request')
+    @mock.patch('zvmconnector.restclient.RESTClient._get_token')
     def test_host_get_info(self, get_token, request):
         method = 'GET'
         url = '/host'

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_host.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_host.py
@@ -46,6 +46,13 @@ class HandlersHostTest(unittest.TestCase):
         self.req = FakeReq()
         self.req.headers['X-Auth-Token'] = payload
 
+    @mock.patch.object(host.HostAction, 'get_guest_list')
+    def test_host_get_guest_list(self, mock_get_guest_list):
+        mock_get_guest_list.return_value = ''
+
+        host.host_get_guest_list(self.req)
+        mock_get_guest_list.assert_called_once_with()
+
     @mock.patch.object(host.HostAction, 'get_info')
     def test_host_get_info(self, mock_get_info):
 

--- a/zvmsdk/tests/unit/sdkwsgi/test_handler.py
+++ b/zvmsdk/tests/unit/sdkwsgi/test_handler.py
@@ -566,6 +566,13 @@ class HostHandlerNegativeTest(unittest.TestCase):
     def setUp(self):
         self.env = env
 
+    def test_host_get_guest_list_invalid(self):
+        self.env['PATH_INFO'] = '/host1/guest'
+        self.env['REQUEST_METHOD'] = 'GET'
+        h = handler.SdkHandler()
+        self.assertRaises(webob.exc.HTTPNotFound,
+                          h, self.env, dummy)
+
     def test_host_get_resource_invalid(self):
         self.env['PATH_INFO'] = '/host1'
         self.env['REQUEST_METHOD'] = 'GET'
@@ -592,6 +599,18 @@ class HostHandlerTest(unittest.TestCase):
 
     def setUp(self):
         self.env = env
+
+    @mock.patch.object(tokens, 'validate')
+    def test_host_get_guest_list(self, mock_validate):
+        self.env['PATH_INFO'] = '/host/guests'
+        self.env['REQUEST_METHOD'] = 'GET'
+        h = handler.SdkHandler()
+        with mock.patch('zvmsdk.sdkwsgi.handlers.host.HostAction.get_guest_list') \
+            as get_guest_list:
+            get_guest_list.return_value = {'overallRC': 0}
+            h(self.env, dummy)
+
+            self.assertTrue(get_guest_list.called)
 
     @mock.patch.object(tokens, 'validate')
     def test_host_get_info(self, mock_validate):

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -276,3 +276,8 @@ class SDKAPITestCase(base.SDKTestCase):
                            'assigner_id': 'user1'}
         self.api.volume_detach(connection_info)
         mock_detach.assert_called_once_with(connection_info)
+
+    @mock.patch("zvmsdk.hostops.HOSTOps.guest_list")
+    def test_guest_get_info(self, guest_list):
+        self.api.host_get_guest_list()
+        guest_list.assert_called_once_with()

--- a/zvmsdk/tests/unit/test_hostops.py
+++ b/zvmsdk/tests/unit/test_hostops.py
@@ -25,6 +25,11 @@ class SDKHostOpsTestCase(base.SDKTestCase):
     def setUp(self):
         self._hostops = hostops.get_hostops()
 
+    @mock.patch("zvmsdk.smtclient.SMTClient.get_all_user_direct")
+    def test_guest_list(self, get_all_user_direct):
+        self._hostops.guest_list()
+        get_all_user_direct.assert_called_once_with()
+
     @mock.patch("zvmsdk.hostops.HOSTOps.diskpool_get_info")
     @mock.patch("zvmsdk.smtclient.SMTClient.get_host_info")
     def test_get_host_info(self, get_host_info, diskpool_get_info):

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -764,6 +764,18 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                          vsw_dict['vswitches'][1]['nics'][1]['nic_rx'])
 
     @mock.patch.object(smtclient.SMTClient, '_request')
+    def test_get_all_user_direct(self, smt_req):
+        resp = ['vm1', 'vm2', 'vm3']
+        smt_req.return_value = {'rs': 0, 'errno': 0, 'strError': '',
+                                'overallRC': 0, 'logEntries': [], 'rc': 0,
+                                'response': resp}
+        expect = ['vm1', 'vm2', 'vm3']
+        rd = 'getvm alldirectory'
+        guest_list = self._smtclient.get_all_user_direct()
+        smt_req.assert_called_once_with(rd)
+        self.assertEqual(guest_list, expect)
+
+    @mock.patch.object(smtclient.SMTClient, '_request')
     def test_get_host_info(self, smt_req):
         resp = ['ZCC USERID: OPNCLOUD',
                 'z/VM Host: OPNSTK2',


### PR DESCRIPTION
Currently there has been same function guest_get_definition_info api to get the user direct of guest, it requires the guest must be in the zcc database.
For the onboarding guest, whether it's in zcc database or not,  we will extract its definition info from hypervisor directly, so add these new interfaces.
I am not sure whether these interfaces would be accepted, so I haven't added the ut cases here.