### PR TITLE
[Mster] Add interfaces to get guest definition info from host

### DIFF
--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -1318,6 +1318,34 @@ Get disk pool information on the host.
 .. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_host_disk_info.tpl
    :language: javascript
 
+Get Guest definition info
+-------------------------
+
+**GET /host/{userid}/def_info**
+
+Get the user direct of the given userid from hypervisor.
+
+* Request:
+
+.. restapi_parameters:: parameters.yaml
+
+  - userid: guest_userid
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
+.. restapi_parameters:: parameters.yaml
+
+  - output: user_direct_guest
+
+* Response sample:
+
+.. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_host_get_guest_definition_info.tpl
+   :language: javascript
+
 Image(s)
 ========
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -424,6 +424,12 @@ def req_host_diskpool_get_info(start_index, *args, **kwargs):
     return url, body
 
 
+def req_host_get_guest_definition_info(start_index, *args, **kwargs):
+    url = '/host/%s/def_info'
+    body = None
+    return url, body
+
+
 def req_image_import(start_index, *args, **kwargs):
     url = '/images'
     body = {'image': {'image_name': args[start_index],
@@ -750,6 +756,11 @@ DATABASE = {
         'args_required': 0,
         'params_path': 0,
         'request': req_host_diskpool_get_info},
+    'host_get_guest_definition_info': {
+        'method': 'GET',
+        'args_required': 1,
+        'params_path': 1,
+        'request': req_host_get_guest_definition_info},
     'image_import': {
         'method': 'POST',
         'args_required': 3,

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -246,6 +246,23 @@ class SDKAPI(object):
         with zvmutils.log_and_reraise_sdkbase_error(action):
             return self._hostops.diskpool_get_info(diskpool_name)
 
+    def host_get_guest_definition_info(self, userid, **kwargs):
+        """Get definition info for the specified guest vm on hypervisor,
+        also could be used to check specific info.
+
+        :param str userid: the user id of the guest vm
+        :param dict kwargs: Dictionary used to check specific info in user
+                            direct. Valid keywords for kwargs:
+                            nic_coupled=<vdev>, where <vdev> is the virtual
+                            device number of the nic to be checked the couple
+                            status.
+        :returns: Dictionary describing user direct and check info result
+        :rtype: dict
+        """
+        action = "get the definition info of guest '%s' on hypervisor" % userid
+        with zvmutils.log_and_reraise_sdkbase_error(action):
+            return self._hostops.get_guest_definition_info(userid, **kwargs)
+
     def image_delete(self, image_name):
         """Delete image from image repository
 

--- a/zvmsdk/hostops.py
+++ b/zvmsdk/hostops.py
@@ -91,3 +91,24 @@ class HOSTOps(object):
                     raise exception.SDKInternalError(msg=errmsg)
 
         return dp_info
+
+    def get_guest_definition_info(self, userid, **kwargs):
+        check_command = ["nic_coupled"]
+        direct_info = self._smtclient.get_user_direct(userid)
+        info = {}
+        info['user_direct'] = direct_info
+
+        for k, v in kwargs.items():
+            if k in check_command:
+                if (k == 'nic_coupled'):
+                    info['nic_coupled'] = False
+                    nstr = "NICDEF %s TYPE QDIO LAN SYSTEM" % v
+                    for inf in direct_info:
+                        if nstr in inf:
+                            info['nic_coupled'] = True
+                            break
+            else:
+                raise exception.SDKInvalidInputFormat(
+                    msg=("invalid check option for user direct: %s") % k)
+
+        return info

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -95,6 +95,9 @@ ROUTE_LIST = (
     ('/host/diskpool', {
         'GET': host.host_get_disk_info,
     }),
+    ('/host/{userid}/def_info', {
+        'GET': host.host_get_guest_definition_info,
+    }),
     ('/images', {
         'POST': image.image_create,
         'GET': image.image_query

--- a/zvmsdk/sdkwsgi/handlers/host.py
+++ b/zvmsdk/sdkwsgi/handlers/host.py
@@ -23,6 +23,7 @@ from zvmsdk.sdkwsgi.handlers import tokens
 from zvmsdk.sdkwsgi import util
 from zvmsdk import utils
 from zvmsdk.sdkwsgi import validation
+from zvmsdk.sdkwsgi.schemas import host
 from zvmsdk.sdkwsgi.schemas import image
 
 
@@ -46,6 +47,12 @@ class HostAction(object):
     def diskpool_get_info(self, req, poolname):
         info = self.client.send_request('host_diskpool_get_info',
                                         disk_pool=poolname)
+        return info
+
+    @validation.query_schema(host.userid_list_query)
+    def get_guest_definition_info(self, req, userid):
+        info = self.client.send_request('host_get_guest_definition_info',
+                                        userid)
         return info
 
 
@@ -84,6 +91,25 @@ def host_get_disk_info(req):
     if 'poolname' in req.GET:
         poolname = req.GET['poolname']
     info = _host_get_disk_info(req, poolname)
+    info_json = json.dumps(info)
+    req.response.status = util.get_http_code_from_sdk_return(info,
+        additional_handler=util.handle_not_found)
+    req.response.body = utils.to_utf8(info_json)
+    req.response.content_type = 'application/json'
+    return req.response
+
+
+@util.SdkWsgify
+@tokens.validate
+def host_get_guest_definition_info(req):
+
+    def _host_get_guest_definition_info(req, userid):
+        action = get_action()
+        return action.get_guest_definition_info(req, userid)
+
+    userid = util.wsgi_path_item(req.environ, 'userid')
+    info = _host_get_guest_definition_info(req, userid)
+
     info_json = json.dumps(info)
     req.response.status = util.get_http_code_from_sdk_return(info,
         additional_handler=util.handle_not_found)

--- a/zvmsdk/sdkwsgi/schemas/host.py
+++ b/zvmsdk/sdkwsgi/schemas/host.py
@@ -1,0 +1,23 @@
+# Copyright 2020 IBM Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from zvmsdk.sdkwsgi.validation import parameter_types
+
+userid_list_query = {
+    'type': 'object',
+    'properties': {
+        'userid': parameter_types.userid_list,
+    },
+    'additionalProperties': False
+}

--- a/zvmsdk/tests/fvt/api_templates/test_host_get_guest_definition_info.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_host_get_guest_definition_info.tpl
@@ -1,0 +1,8 @@
+{
+    "rs": 0,
+    "overallRC": 0,
+    "modID": null,
+    "rc": 0,
+    "errmsg": "",
+    "output": {"user_direct": ["USER1", "INCLUDE PROFILE"]}
+}

--- a/zvmsdk/tests/fvt/test_host.py
+++ b/zvmsdk/tests/fvt/test_host.py
@@ -47,3 +47,9 @@ class HostTestCase(base.ZVMConnectorBaseTestCase):
         url = '/host/diskpool?poolname=%s' % 'xxxx:dummy'
         resp = self.client.api_request(url)
         self.assertEqual(400, resp.status_code)
+
+    def test_host_get_guest_definition_info(self):
+        resp = self.client.api_request(url='/host/USER1/def_info')
+        self.assertEqual(200, resp.status_code)
+        self.apibase.verify_result('test_host_get_guest_definition_info',
+                                   resp.content)

--- a/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
+++ b/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
@@ -629,6 +629,22 @@ class RESTClientTestCase(unittest.TestCase):
 
     @mock.patch.object(requests, 'request')
     @mock.patch('zvmconnector.restclient.RESTClient._get_token')
+    def test_host_get_guest_definition_info(self, get_token, request):
+        method = 'GET'
+        url = '/host/%s/def_info' % self.fake_userid
+        body = None
+        header = self.headers
+        full_uri = self.base_url + url
+        request.return_value = self.response
+        get_token.return_value = self._tmp_token()
+
+        self.client.call("host_get_guest_definition_info", self.fake_userid)
+        request.assert_called_with(method, full_uri,
+                                   data=body, headers=header,
+                                   verify=False)
+
+    @mock.patch.object(requests, 'request')
+    @mock.patch('zvmconnector.restclient.RESTClient._get_token')
     def test_image_import(self, get_token, request):
         method = 'POST'
         image_uri = 'file:///tmp/100.img'

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_host.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_host.py
@@ -18,6 +18,10 @@ import mock
 import unittest
 
 from zvmsdk.sdkwsgi.handlers import host
+from zvmsdk.sdkwsgi import util
+
+
+FAKE_USERID = 'noexist'
 
 
 class FakeResp(object):
@@ -61,3 +65,12 @@ class HandlersHostTest(unittest.TestCase):
         self.req.GET['poolname'] = 'disk1'
         host.host_get_disk_info(self.req)
         self.assertTrue(mock_get_disk_info.called)
+
+    @mock.patch.object(util, 'wsgi_path_item')
+    @mock.patch.object(host.HostAction, 'get_guest_definition_info')
+    def test_host_get_guest_definition_info(self, mock_get, mock_userid):
+        mock_get.return_value = ''
+        mock_userid.return_value = FAKE_USERID
+
+        host.host_get_guest_definition_info(self.req)
+        mock_get.assert_called_once_with(self.req, FAKE_USERID)

--- a/zvmsdk/tests/unit/sdkwsgi/test_handler.py
+++ b/zvmsdk/tests/unit/sdkwsgi/test_handler.py
@@ -617,6 +617,19 @@ class HostHandlerTest(unittest.TestCase):
 
             get_disk_info.assert_called_once_with(mock.ANY, None)
 
+    @mock.patch.object(tokens, 'validate')
+    def test_host_get_guest_definition_info(self, mock_validate):
+        self.env['PATH_INFO'] = '/host/1/def_info'
+        self.env['REQUEST_METHOD'] = 'GET'
+        h = handler.SdkHandler()
+        func = 'zvmsdk.sdkwsgi.handlers.host.HostAction' \
+               '.get_guest_definition_info'
+        with mock.patch(func) as get:
+            get.return_value = {'overallRC': 0}
+            h(self.env, dummy)
+
+            get.assert_called_once_with(mock.ANY, '1')
+
 
 class VswitchHandlerNegativeTest(unittest.TestCase):
 

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -434,3 +434,8 @@ class SDKAPITestCase(base.SDKTestCase):
         guestdb_del.assert_called_once_with(self.userid)
         networkdb_del.assert_called_once_with(self.userid)
         chk_usr.assert_called_once_with(self.userid)
+
+    @mock.patch("zvmsdk.hostops.HOSTOps.get_guest_definition_info")
+    def test_host_get_guest_definition_info(self, ginfo):
+        self.api.host_get_guest_definition_info(self.userid)
+        ginfo.assert_called_once_with(self.userid)

--- a/zvmsdk/tests/unit/test_hostops.py
+++ b/zvmsdk/tests/unit/test_hostops.py
@@ -69,3 +69,13 @@ class SDKHostOpsTestCase(base.SDKTestCase):
         self.assertEqual(dp_info['disk_total'], 406105)
         self.assertEqual(dp_info['disk_used'], 367263)
         self.assertEqual(dp_info['disk_available'], 38)
+
+    @mock.patch("zvmsdk.smtclient.SMTClient.get_user_direct")
+    def test_get_guest_definition_info(self, get_user_direct):
+        get_user_direct.return_value = [
+            'line1',
+            'NICDEF 1000 TYPE QDIO LAN SYSTEM VSWITCH']
+
+        self._hostops.get_guest_definition_info("fake_user_id",
+                                                nic_coupled='1000')
+        get_user_direct.assert_called_with("fake_user_id")


### PR DESCRIPTION
Currently there has been the function guest_get_definition_info api to get the user direct of guest, it requires the guest must be in the zcc database.
For the onboarding guest, whether it's in zcc database or not,  we will extract its definition info from hypervisor directly, so add these new interfaces.
I am not sure whether these interfaces would be accepted, so I haven't added the ut cases here.