### PR TITLE
[1.5.n] update guest_create API to support boot from volume

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -184,6 +184,23 @@ guest_ipl_loadparam:
   in: body
   required: false
   type: string
+
+guest_dedicate_vdevs:
+  description: |
+    A list of device vdevs to dedicate to the guest。
+  in: body
+  required: false
+  type: list
+
+guest_loaddev:
+  description: |
+    The loaddev parms to add in the guest directory.Current supported key includes 'portname'
+    and 'lun'. Both the 'portname' and 'lun' can specify only one one- to
+    eight-byte hexadecimal value in the range of 0-FFFFFFFFFFFFFFFF.
+  in: body
+  required: false
+  type: dict
+
 guest_max_cpu:
   description: |
     The maximum number of virtual cpus this user can define.

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -146,6 +146,8 @@ Create a vm in z/VM
   - ipl_from: guest_ipl_from
   - ipl_param: guest_ipl_param
   - ipl_loadparam: guest_ipl_loadparam
+  - dedicate_vdevs: guest_dedicate_vdevs
+  - loaddev: guest_loaddev
 
 
 * Request sample:

--- a/smtLayer/makeVM.py
+++ b/smtLayer/makeVM.py
@@ -70,7 +70,10 @@ keyOpsList = {
         '--setReservedMem': ['setReservedMem', 0, 0],
         '--showparms': ['showParms', 0, 0],
         '--iplParam': ['iplParam', 1, 2],
-        '--iplLoadparam': ['iplLoadparam', 1, 2]},
+        '--iplLoadparam': ['iplLoadparam', 1, 2],
+        '--dedicate': ['dedicate', 1, 2],
+        '--loadportname': ['loadportname', 1, 2],
+        '--loadlun': ['loadlun', 1, 2]},
     'HELP': {},
     'VERSION': {},
      }
@@ -97,6 +100,7 @@ def createVM(rh):
     dirLines.append("USER " + rh.userid + " " + rh.parms['pw'] +
          " " + rh.parms['priMemSize'] + " " +
          rh.parms['maxMemSize'] + " " + rh.parms['privClasses'])
+
     if 'profName' in rh.parms:
         dirLines.append("INCLUDE " + rh.parms['profName'])
 
@@ -133,6 +137,20 @@ def createVM(rh):
             return rh.results['overallRC']
         if reservedSize != '0M':
             dirLines.append("COMMAND DEF STOR RESERVED %s" % reservedSize)
+
+    if 'loadportname' in rh.parms:
+        wwpn = rh.parms['loadportname'].replace("0x", "")
+        dirLines.append("LOADDEV PORTname %s" % wwpn)
+
+    if 'loadlun' in rh.parms:
+        lun = rh.parms['loadlun'].replace("0x", "")
+        dirLines.append("LOADDEV LUN %s" % lun)
+
+    if 'dedicate' in rh.parms:
+        vdevs = rh.parms['dedicate'].split()
+        # add a DEDICATE statement for each vdev
+        for vdev in vdevs:
+            dirLines.append("DEDICATE %s %s" % (vdev, vdev))
 
     # Construct the temporary file for the USER entry.
     fd, tempFile = mkstemp()
@@ -301,6 +319,9 @@ def showInvLines(rh):
         "--profile <profName>")
     rh.printLn("N", "                     --maxCPU <maxCPUCnt> " +
         "--setReservedMem")
+    rh.printLn("N", "                     --dedicate <vdevs> ")
+    rh.printLn("N", "                     --loadportname <wwpn> " +
+        "--loadlun <lun>")
     rh.printLn("N", "  python " + rh.cmdName + " MakeVM help")
     rh.printLn("N", "  python " + rh.cmdName + " MakeVM version")
     return
@@ -337,6 +358,22 @@ def showOperandLines(rh):
                    "Specifies an IPL disk or NSS for the virtual")
         rh.printLn("N", "                              " +
                    "machine's directory entry.")
+        rh.printLn("N", "      --dedicate <vdevs>     - " +
+                   "Specifies a device vdev list to dedicate to the ")
+        rh.printLn("N", "                              " +
+                   "virtual machine.")
+        rh.printLn("N", "      --loadportname <wwpn> - " +
+                   "Specifies a one- to eight-byte fibre channel port ")
+        rh.printLn("N", "                              " +
+                   "name of the FCP-I/O device to define with a LOADDEV ")
+        rh.printLn("N", "                              " +
+                   "statement in the virtual machine's definition")
+        rh.printLn("N", "      --loadlun <lun>       - " +
+                   "Specifies a one- to eight-byte logical unit number ")
+        rh.printLn("N", "                              " +
+                   "name of the FCP-I/O device to define with a LOADDEV ")
+        rh.printLn("N", "                              " +
+                   "statement in the virtual machine's definition")
         rh.printLn("N", "      --logonby <byUsers>   - " +
                    "Specifies a list of up to 8 z/VM userids who can log")
         rh.printLn("N", "                              " +

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -67,6 +67,10 @@ class VMHandler(object):
             kwargs_list['ipl_param'] = guest['ipl_param']
         if 'ipl_loadparam' in guest_keys:
             kwargs_list['ipl_loadparam'] = guest['ipl_loadparam']
+        if 'dedicate_vdevs' in guest_keys:
+            kwargs_list['dedicate_vdevs'] = guest['dedicate_vdevs']
+        if 'loaddev' in guest_keys:
+            kwargs_list['loaddev'] = guest['loaddev']
 
         info = self.client.send_request('guest_create', userid, vcpus,
                                         memory, **kwargs_list)

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -32,6 +32,8 @@ create = {
                 'ipl_from': parameter_types.ipl_from,
                 'ipl_param': parameter_types.ipl_param,
                 'ipl_loadparam': parameter_types.ipl_loadparam,
+                'dedicate_vdevs': parameter_types.vdev_list,
+                'loaddev': parameter_types.loaddev
             },
             'required': ['userid', 'vcpus', 'memory'],
             'additionalProperties': False,

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -117,6 +117,20 @@ ipl_loadparam = {
     'type': 'string', 'minLength': 0, 'maxLength': 255,
 }
 
+loaddev = {
+    'type': 'object',
+    'properties': {
+        'portname': {'type': 'string',
+                     'minLength': 1,
+                     'maxLength': 16,
+                     'pattern': '^[0-9a-fA-F]{,16}$'},
+        'lun': {'type': 'string',
+                'minLength': 1,
+                'maxLength': 16,
+                'pattern': '^[0-9a-fA-F]{,16}$'},
+    },
+    'additionalProperties': False
+}
 
 positive_integer = {
     'type': ['integer', 'string'],

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -84,7 +84,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile, max_cpu, max_mem)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                   disk_list, user_profile, max_cpu, max_mem,
-                                  '', '', '')
+                                  '', '', '', [], {})
 
     @mock.patch("zvmsdk.vmops.VMOps.create_vm")
     def test_guest_create_with_default_max_cpu_memory(self, create_vm):
@@ -97,7 +97,7 @@ class SDKAPITestCase(base.SDKTestCase):
                               user_profile)
         create_vm.assert_called_once_with(self.userid, vcpus, memory,
                                           disk_list, user_profile, 32, '64G',
-                                          '', '', '')
+                                          '', '', '', [], {})
 
     @mock.patch("zvmsdk.imageops.ImageOps.image_query")
     def test_image_query(self, image_query):

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -152,7 +152,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
               '--logonby "lbyuser1 lbyuser2" --ipl 0100')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
-                                   max_cpu, max_mem, '', '', '')
+                                   max_cpu, max_mem, '', '', '', [], {})
         request.assert_called_with(rd)
         add_mdisks.assert_called_with(user_id, disk_list)
         add_guest.assert_called_with(user_id)
@@ -177,7 +177,37 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
               '--logonby "lbyuser1 lbyuser2" --ipl cms')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
-                                  max_cpu, max_mem, 'cms', '', '')
+                                  max_cpu, max_mem, 'cms', '', '', [], {})
+        request.assert_called_with(rd)
+        add_mdisks.assert_called_with(user_id, disk_list)
+        add_guest.assert_called_with(user_id)
+
+    @mock.patch.object(smtclient.SMTClient, 'add_mdisks')
+    @mock.patch.object(smtclient.SMTClient, '_request')
+    @mock.patch.object(database.GuestDbOperator, 'add_guest')
+    def test_create_vm_boot_from_volume(self, add_guest, request, add_mdisks):
+        user_id = 'fakeuser'
+        cpu = 2
+        memory = 1024
+        disk_list = [{'size': '1g',
+                      'disk_pool': 'ECKD:eckdpool1',
+                      'format': 'ext3'}]
+        profile = 'osdflt'
+        max_cpu = 10
+        max_mem = '4G'
+        base.set_conf('zvm', 'default_admin_userid', 'lbyuser1 lbyuser2')
+        base.set_conf('zvm', 'user_root_vdev', '0100')
+        ipl_from = '5c71'
+        dedicate_vdevs = ['5c71', '5d71']
+        loaddev = {'portname': '5005076802400c1b',
+                   'lun': '0000000000000000'}
+        rd = ('makevm fakeuser directory LBYONLY 1024m G --cpus 2 '
+              '--profile osdflt --maxCPU 10 --maxMemSize 4G --setReservedMem '
+              '--logonby "lbyuser1 lbyuser2" --ipl 5c71 --dedicate "5c71 5d71" '
+              '--loadportname 5005076802400c1b --loadlun 0000000000000000')
+        self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
+                                   max_cpu, max_mem, ipl_from, '', '',
+                                   dedicate_vdevs, loaddev)
         request.assert_called_with(rd)
         add_mdisks.assert_called_with(user_id, disk_list)
         add_guest.assert_called_with(user_id)
@@ -206,7 +236,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
               '--iplLoadparam load=1')
         self._smtclient.create_vm(user_id, cpu, memory, disk_list, profile,
                                   max_cpu, max_mem, 'cms', ipl_param,
-                                  ipl_loadparam)
+                                  ipl_loadparam, [], {})
         request.assert_called_with(rd)
         add_mdisks.assert_called_with(user_id, disk_list)
         add_guest.assert_called_with(user_id)

--- a/zvmsdk/tests/unit/test_vmops.py
+++ b/zvmsdk/tests/unit/test_vmops.py
@@ -62,11 +62,13 @@ class SDKVMOpsTestCase(base.SDKTestCase):
         user_profile = 'testprof'
         max_cpu = 10
         max_mem = '4G'
+        vdevs = ['1234']
+        loaddev = {'portname': '5678', 'lun': '0000000000000000'}
         self.vmops.create_vm(userid, cpu, memory, disk_list, user_profile,
-                             max_cpu, max_mem, '', '', '')
+                             max_cpu, max_mem, '', '', '', vdevs, loaddev)
         create_vm.assert_called_once_with(userid, cpu, memory, disk_list,
                                           user_profile, max_cpu, max_mem,
-                                          '', '', '')
+                                          '', '', '', vdevs, loaddev)
         namelistadd.assert_called_once_with('TSTNLIST', userid)
 
     @mock.patch("zvmsdk.smtclient.SMTClient.process_additional_minidisks")

--- a/zvmsdk/vmops.py
+++ b/zvmsdk/vmops.py
@@ -166,14 +166,15 @@ class VMOps(object):
 
     def create_vm(self, userid, cpu, memory, disk_list,
                   user_profile, max_cpu, max_mem, ipl_from,
-                  ipl_param, ipl_loadparam):
+                  ipl_param, ipl_loadparam, dedicate_vdevs, loaddev):
         """Create z/VM userid into user directory for a z/VM instance."""
         LOG.info("Creating the user directory for vm %s", userid)
 
         info = self._smtclient.create_vm(userid, cpu, memory,
                                    disk_list, user_profile,
                                    max_cpu, max_mem, ipl_from,
-                                   ipl_param, ipl_loadparam)
+                                   ipl_param, ipl_loadparam,
+                                   dedicate_vdevs, loaddev)
 
         # add userid into smapi namelist
         self._smtclient.namelist_add(self._namelist, userid)


### PR DESCRIPTION
add two new parameter to guest_create:
dedicate_vdevs: used to dedicate devices like fcp;
loaddev: used to add the loaddev portname and lun statement in the guest definition

Signed-off-by: dyyang <dyyang@cn.ibm.com>