### PR TITLE
[1.5.n]Add time stamp in image query

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -1086,3 +1086,10 @@ size_output:
   in: body
   required: true
   type: string
+last_access_time:
+  description: |
+    the time stamp of last access time of this image
+    the seconds count after 1970 and is generated from python ``time`` module.
+  in: body
+  required: true
+  type: float

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -1323,6 +1323,7 @@ Get the list of image info in image repository.
   - image_size_in_bytes: physical_disk_size_image
   - type: image_type
   - comments: image_comments
+  - last_access_time: last_access_time
 
 * Response sample:
 

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -217,6 +217,8 @@ errors = {
                21: "Image Export error: Failed to copy image file to remote "
                    "host with reason: %(msg)s",
                22: "Export image to local file system failed: %(err)s",
+               23: "Image file of %(img)s does not exist, "
+                   "so failed to get its timestamp.",
                },
               "Operation on Image failed"
               ],


### PR DESCRIPTION
add timestamp info to support manage_image_cache API in nova ZVM driver