### PR TITLE
[master] Update image_get_os_distro and _get_image_disk_type

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -2292,7 +2292,7 @@ class SMTClient(object):
         """
         Return the operating system distro of the specified image
         """
-        image_info = self.image_query(image_name)
+        image_info = self._ImageDbOperator.image_query_record(image_name)
         if not image_info:
             raise exception.SDKImageOperationError(rs=20, img=image_name)
         os_distro = image_info[0]['imageosdistro']
@@ -2302,7 +2302,7 @@ class SMTClient(object):
         """
         Return image disk type
         """
-        image_info = self.image_query(image_name)
+        image_info = self._ImageDbOperator.image_query_record(image_name)
         if ((image_info[0]['comments'] is not None) and
             (image_info[0]['comments'].__contains__('disk_type'))):
             image_disk_type = eval(image_info[0]['comments'])['disk_type']

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -525,7 +525,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         mkdtemp.assert_called_with()
         cleantemp.assert_called_with('/tmp/tmpdir')
 
-    @mock.patch.object(smtclient.SMTClient, 'image_query')
+    @mock.patch.object(database.ImageDbOperator, 'image_query_record')
     def test_image_get_os_distro(self, image_info):
         image_info.return_value = [{'image_size_in_bytes': '3072327680',
                                     'disk_size_units': '3339:CYL',
@@ -539,7 +539,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         self.assertEqual(self._smtclient.image_get_os_distro(image_info),
                          'RHCOS4')
 
-    @mock.patch.object(smtclient.SMTClient, 'image_query')
+    @mock.patch.object(database.ImageDbOperator, 'image_query_record')
     def test_get_image_disk_type_dasd(self, image_info):
         image_info.return_value = [{'image_size_in_bytes': '3072327680',
                                     'disk_size_units': '3339:CYL',
@@ -553,7 +553,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         self.assertEqual(self._smtclient._get_image_disk_type(image_info),
                          'ECKD')
 
-    @mock.patch.object(smtclient.SMTClient, 'image_query')
+    @mock.patch.object(database.ImageDbOperator, 'image_query_record')
     def test_get_image_disk_type_scsi(self, image_info):
         image_info.return_value = [{'image_size_in_bytes': '3072327680',
                                     'disk_size_units': '3339:CYL',
@@ -567,7 +567,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         self.assertEqual(self._smtclient._get_image_disk_type(image_info),
                          'SCSI')
 
-    @mock.patch.object(smtclient.SMTClient, 'image_query')
+    @mock.patch.object(database.ImageDbOperator, 'image_query_record')
     def test_get_image_disk_type_failed(self, image_info):
         image_info.return_value = [{'image_size_in_bytes': '3072327680',
                                     'disk_size_units': '3339:CYL',


### PR DESCRIPTION
In smtclient.image_get_os_distro and smtclient._get_image_disk_type, image_query
is changed to ImageDbOperator.image_query_record to improve efficiency.