### PR TITLE
[Master]Add image clean in snapshot

### DIFF
--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -444,6 +444,12 @@ def req_host_diskpool_get_info(start_index, *args, **kwargs):
     return url, body
 
 
+def req_get_free_space_on_zcc(start_index, *args, **kwargs):
+    url = '/host/zccfreespace'
+    body = None
+    return url, body
+
+
 def req_image_import(start_index, *args, **kwargs):
     url = '/images'
     body = {'image': {'image_name': args[start_index],
@@ -785,6 +791,11 @@ DATABASE = {
         'args_required': 0,
         'params_path': 0,
         'request': req_host_diskpool_get_info},
+    'get_free_space_on_zcc': {
+        'method': 'GET',
+        'args_required': 0,
+        'params_path': 0,
+        'request': req_get_free_space_on_zcc},
     'image_import': {
         'method': 'POST',
         'args_required': 3,

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -274,6 +274,11 @@ class SDKAPI(object):
         with zvmutils.log_and_reraise_sdkbase_error(action):
             return self._hostops.diskpool_get_info(diskpool_name)
 
+    def get_free_space_on_zcc(self):
+        action = "get free disk space on zcc."
+        with zvmutils.log_and_reraise_sdkbase_error(action):
+            return self._hostops.get_free_space_on_zcc()
+
     def image_delete(self, image_name):
         """Delete image from image repository
 

--- a/zvmsdk/hostops.py
+++ b/zvmsdk/hostops.py
@@ -96,3 +96,6 @@ class HOSTOps(object):
                     raise exception.SDKInternalError(msg=errmsg)
 
         return dp_info
+
+    def get_free_space_on_zcc(self):
+        return self._smtclient.get_free_space_on_zcc()

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -104,6 +104,9 @@ ROUTE_LIST = (
     ('/host/diskpool', {
         'GET': host.host_get_disk_info,
     }),
+    ('/host/zccfreespace', {
+        'GET': host.get_free_space_on_zcc,
+    }),
     ('/images', {
         'POST': image.image_create,
         'GET': image.image_query

--- a/zvmsdk/sdkwsgi/handlers/host.py
+++ b/zvmsdk/sdkwsgi/handlers/host.py
@@ -46,6 +46,10 @@ class HostAction(object):
         info = self.client.send_request('host_get_guest_list')
         return info
 
+    def get_free_space_on_zcc(self):
+        info = self.client.send_request('get_free_space_on_zcc')
+        return info
+
     @validation.query_schema(image.diskpool)
     def diskpool_get_info(self, req, poolname):
         info = self.client.send_request('host_diskpool_get_info',
@@ -104,6 +108,23 @@ def host_get_disk_info(req):
     if 'poolname' in req.GET:
         poolname = req.GET['poolname']
     info = _host_get_disk_info(req, poolname)
+    info_json = json.dumps(info)
+    req.response.status = util.get_http_code_from_sdk_return(info,
+        additional_handler=util.handle_not_found)
+    req.response.body = utils.to_utf8(info_json)
+    req.response.content_type = 'application/json'
+    return req.response
+
+
+@util.SdkWsgify
+@tokens.validate
+def get_free_space_on_zcc(req):
+
+    def _host_get_free_space_on_zcc():
+        action = get_action()
+        return action.get_free_space_on_zcc()
+
+    info = _host_get_free_space_on_zcc()
     info_json = json.dumps(info)
     req.response.status = util.get_http_code_from_sdk_return(info,
         additional_handler=util.handle_not_found)

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -572,6 +572,14 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         mkdtemp.assert_called_with()
         cleantemp.assert_called_with('/tmp/tmpdir')
 
+    @mock.patch.object(zvmutils, 'execute')
+    def test_get_free_space_on_zcc(self, execute_cmd):
+        output = ("Filesystem      Size  Used Avail Use% Mounted on\n"
+                  "/dev/dasda1     9.8G  6.9G  2.4G  75% /")
+        execute_cmd.return_value = (0, output)
+        ret = self._smtclient.get_free_space_on_zcc()
+        self.assertEqual(ret, '2.4')
+
     @mock.patch.object(database.ImageDbOperator, 'image_query_record')
     def test_image_get_os_distro(self, image_info):
         image_info.return_value = [{'image_size_in_bytes': '3072327680',


### PR DESCRIPTION
Add a new REST API get_free_space_on_zcc to support adding image clean up in snapshot in ZVM driver.

this get_free_space_on_zcc will execute 'df -h /' on zcc and return the data of free space.