### PR TITLE
[1.5.n] update guest_deploy to support boot from volume

### DIFF
--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -44,6 +44,7 @@
 300;40;300;20;The image record of %(img)s does not exist
 300;40;300;21;Image Export error: Failed to copy image file to remote host with reason: %(msg)s
 300;40;300;22;Export image to local file system failed: %(err)s
+300;40;300;23;Image file of %(img)s does not exist, so failed to get its timestamp.
 **Operation on Monitor failed**
 300;50;300;1;Database operation failed, error: %(msg)s
 **REST API Request error**

--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -669,6 +669,15 @@ deploy_hostname:
   in: body
   required: false
   type: string
+deploy_skipdiskcopy:
+  description: |
+    whether to skip the copy of image to disk. Default value if False.
+    If the value is True, the ``image_name`` specified should be the os version.
+    If the value is False, the ``image_name`` specified should be the name of the image
+    to be used to copy to the root disk.
+  in: body
+  required: false
+  type: boolean
 capture_type:
   description: |
     The type of capture\:

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -1110,6 +1110,7 @@ After guest created, deploy image onto the guest.
   - remotehost: remotehost_transportfiles
   - vdev: deploy_vdev
   - hostname: deploy_hostname
+  - skipdiskcopy: deploy_skipdiskcopy
 
 * Request sample:
 

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -337,23 +337,29 @@ class SDKAPI(object):
 
     @check_guest_exist()
     def guest_deploy(self, userid, image_name, transportfiles=None,
-                     remotehost=None, vdev=None, hostname=None):
+                     remotehost=None, vdev=None, hostname=None,
+                     skipdiskcopy=False):
         """ Deploy the image to vm.
 
         :param userid: (str) the user id of the vm
-        :param image_name: (str) the name of image that used to deploy the vm
+        :param image_name: (str) If the skipdiskcopy is False, this would be
+               used as the name of image that used to deploy the vm;
+               Otherwise, this value should be the os version.
         :param transportfiles: (str) the files that used to customize the vm
         :param remotehost: the server where the transportfiles located, the
                format is username@IP, eg nova@192.168.99.1
         :param vdev: (str) the device that image will be deploy to
         :param hostname: (str) the hostname of the vm. This parameter will be
                ignored if transportfiles present.
+        :param skipdiskcopy: (bool) whether to skip the disk copy process.
+               If True, the os version should be specified in the parameter
+               image_name.
         """
         action = ("deploy image '%(img)s' to guest '%(vm)s'" %
                   {'img': image_name, 'vm': userid})
         with zvmutils.log_and_reraise_sdkbase_error(action):
             self._vmops.guest_deploy(userid, image_name, transportfiles,
-                                     remotehost, vdev, hostname)
+                                     remotehost, vdev, hostname, skipdiskcopy)
 
     @check_guest_exist()
     def guest_capture(self, userid, image_name, capture_type='rootonly',

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -344,13 +344,15 @@ class VMAction(object):
         remotehost = body.get('remotehost', None)
         vdev = body.get('vdev', None)
         hostname = body.get('hostname', None)
+        skipdiskcopy = body.get('skipdiskcopy', False)
 
         request_info = ("action: 'deploy', userid: %(userid)s,"
                         "transportfiles: %(trans)s, remotehost: %(remote)s,"
-                        "vdev: %(vdev)s" %
+                        "vdev: %(vdev)s, skipdiskcopy: %(skipdiskcopy)s" %
                         {'userid': userid, 'trans': transportfiles,
                          'remote': remotehost, 'vdev': vdev,
-                         'hostname': hostname
+                         'hostname': hostname,
+                         'skipdiskcopy': skipdiskcopy,
                          })
 
         info = None
@@ -371,7 +373,8 @@ class VMAction(object):
                                             image_name,
                                             transportfiles=transportfiles,
                                             remotehost=remotehost,
-                                            vdev=vdev, hostname=hostname)
+                                            vdev=vdev, hostname=hostname,
+                                            skipdiskcopy=skipdiskcopy)
         finally:
             try:
                 self.dd_semaphore.release()

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -196,6 +196,7 @@ deploy = {
         'remotehost': parameter_types.remotehost,
         'vdev': parameter_types.vdev,
         'hostname': parameter_types.hostname,
+        'skipdiskcopy': parameter_types.boolean,
     },
     'required': ['image'],
     'additionalProperties': False,

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -647,31 +647,36 @@ class SMTClient(object):
             self._pathutils.clean_temp_folder(iucv_path)
 
     def guest_deploy(self, userid, image_name, transportfiles=None,
-                     remotehost=None, vdev=None):
+                     remotehost=None, vdev=None, skipdiskcopy=False):
         """ Deploy image and punch config driver to target """
         # (TODO: add the support of multiple disks deploy)
-        msg = ('Start to deploy image %(img)s to guest %(vm)s'
+        if skipdiskcopy:
+            msg = ('Start guest_deploy without unpackdiskimage, guest: %(vm)s'
+                   'os_version: %(img)s' % {'img': image_name, 'vm': userid})
+            LOG.info(msg)
+        else:
+            msg = ('Start to deploy image %(img)s to guest %(vm)s'
                 % {'img': image_name, 'vm': userid})
-        LOG.info(msg)
-        image_file = '/'.join([self._get_image_path_by_name(image_name),
-                               CONF.zvm.user_root_vdev])
-        # Unpack image file to root disk
-        vdev = vdev or CONF.zvm.user_root_vdev
-        cmd = ['sudo', '/opt/zthin/bin/unpackdiskimage', userid, vdev,
-               image_file]
-        with zvmutils.expect_and_reraise_internal_error(modID='guest'):
-            (rc, output) = zvmutils.execute(cmd)
-        if rc != 0:
-            err_msg = ("unpackdiskimage failed with return code: %d." % rc)
-            err_output = ""
-            output_lines = output.split('\n')
-            for line in output_lines:
-                if line.__contains__("ERROR:"):
-                    err_output += ("\\n" + line.strip())
-            LOG.error(err_msg + err_output)
-            raise exception.SDKGuestOperationError(rs=3, userid=userid,
-                                                   unpack_rc=rc,
-                                                   err=err_output)
+            LOG.info(msg)
+            image_file = '/'.join([self._get_image_path_by_name(image_name),
+                                   CONF.zvm.user_root_vdev])
+            # Unpack image file to root disk
+            vdev = vdev or CONF.zvm.user_root_vdev
+            cmd = ['sudo', '/opt/zthin/bin/unpackdiskimage', userid, vdev,
+                   image_file]
+            with zvmutils.expect_and_reraise_internal_error(modID='guest'):
+                (rc, output) = zvmutils.execute(cmd)
+            if rc != 0:
+                err_msg = ("unpackdiskimage failed with return code: %d." % rc)
+                err_output = ""
+                output_lines = output.split('\n')
+                for line in output_lines:
+                    if line.__contains__("ERROR:"):
+                        err_output += ("\\n" + line.strip())
+                LOG.error(err_msg + err_output)
+                raise exception.SDKGuestOperationError(rs=3, userid=userid,
+                                                       unpack_rc=rc,
+                                                       err=err_output)
 
         # Purge guest reader to clean dirty data
         rd = ("changevm %s purgerdr" % userid)
@@ -720,11 +725,20 @@ class SMTClient(object):
         self.guest_authorize_iucv_client(userid)
         # Update os version in guest metadata
         # TODO: may should append to old metadata, not replace
-        image_info = self._ImageDbOperator.image_query_record(image_name)
-        metadata = 'os_version=%s' % image_info[0]['imageosdistro']
+        if skipdiskcopy:
+            os_version = image_name
+        else:
+            image_info = self._ImageDbOperator.image_query_record(image_name)
+            os_version = image_info[0]['imageosdistro']
+        metadata = 'os_version=%s' % os_version
         self._GuestDbOperator.update_guest_by_userid(userid, meta=metadata)
 
-        msg = ('Deploy image %(img)s to guest %(vm)s disk %(vdev)s'
+        if skipdiskcopy:
+            msg = ('guest_deploy without unpackdiskimage finish successfully, '
+                   'guest: %(vm)s, os_version: %(img)s'
+                   % {'img': image_name, 'vm': userid})
+        else:
+            msg = ('Deploy image %(img)s to guest %(vm)s disk %(vdev)s'
                ' successfully' % {'img': image_name, 'vm': userid,
                                   'vdev': vdev})
         LOG.info(msg)

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
@@ -331,7 +331,7 @@ class GuestActionsTest(SDKWSGITest):
         guest.guest_action(self.req)
         mock_action.assert_called_once_with('guest_deploy', FAKE_USERID,
             'image1', remotehost='test@host1.x.y', transportfiles='file1',
-            vdev='1000', hostname=None)
+            vdev='1000', hostname=None, skipdiskcopy=False)
 
     @mock.patch.object(util, 'wsgi_path_item')
     def test_guest_deploy_missing_param(self, mock_userid):
@@ -384,7 +384,8 @@ class GuestActionsTest(SDKWSGITest):
         guest.guest_action(self.req)
         mock_action.assert_called_once_with('guest_deploy', FAKE_USERID,
             'image1', remotehost='test@192.168.99.99',
-            transportfiles='file1', vdev='1000', hostname=None)
+            transportfiles='file1', vdev='1000', hostname=None,
+            skipdiskcopy=False)
 
     @mock.patch.object(util, 'wsgi_path_item')
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
@@ -402,7 +403,8 @@ class GuestActionsTest(SDKWSGITest):
         guest.guest_action(self.req)
         mock_action.assert_called_once_with('guest_deploy', FAKE_USERID,
             'image1', remotehost='test123@test.xyz.com',
-            transportfiles='file1', vdev='1000', hostname=None)
+            transportfiles='file1', vdev='1000', hostname=None,
+            skipdiskcopy=False)
 
     @mock.patch.object(util, 'wsgi_path_item')
     def test_guest_deploy_without_username_in_remotehost(self,

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -51,7 +51,8 @@ class SDKAPITestCase(base.SDKTestCase):
                               transportfiles=transportfiles,
                               vdev=vdev)
         guest_deploy.assert_called_with(user_id.upper(), image_name,
-                                        transportfiles, None, vdev, None)
+                                        transportfiles, None, vdev,
+                                        None, False)
 
     @mock.patch("zvmsdk.imageops.ImageOps.image_import")
     def test_image_import(self, image_import):

--- a/zvmsdk/tests/unit/test_vmops.py
+++ b/zvmsdk/tests/unit/test_vmops.py
@@ -161,7 +161,7 @@ class SDKVMOpsTestCase(base.SDKTestCase):
         image_get_os_distro.assert_called_once_with('fakeimg')
         deploy_image_to_vm.assert_called_with('fakevm', 'fakeimg',
                                               '/test/transport.tgz', None,
-                                              None)
+                                              None, False)
 
     @mock.patch("zvmsdk.smtclient.SMTClient._get_image_last_access_time")
     @mock.patch('zvmsdk.vmops.VMOps.set_hostname')
@@ -175,7 +175,7 @@ class SDKVMOpsTestCase(base.SDKTestCase):
         self.vmops.guest_deploy('fakevm', 'fakeimg',
                                 hostname=fake_hostname)
         deploy_image_to_vm.assert_called_with('fakevm', 'fakeimg', None, None,
-                                              None)
+                                              None, False)
         img_query.assert_called_once_with('fakeimg')
         set_hostname.assert_called_once_with('fakevm', fake_hostname,
                                              'rhel6.7')

--- a/zvmsdk/vmops.py
+++ b/zvmsdk/vmops.py
@@ -271,12 +271,16 @@ class VMOps(object):
             self._pathutils.clean_temp_folder(tmp_path)
 
     def guest_deploy(self, userid, image_name, transportfiles=None,
-                     remotehost=None, vdev=None, hostname=None):
+                     remotehost=None, vdev=None, hostname=None,
+                     skipdiskcopy=False):
         LOG.info("Begin to deploy image on vm %s", userid)
-        os_version = self._smtclient.image_get_os_distro(image_name)
+        if not skipdiskcopy:
+            os_version = self._smtclient.image_get_os_distro(image_name)
+        else:
+            os_version = image_name
         if not os_version.lower().startswith('rhcos'):
             self._smtclient.guest_deploy(userid, image_name, transportfiles,
-                                         remotehost, vdev)
+                                         remotehost, vdev, skipdiskcopy)
 
             # punch scripts to set hostname
             if (transportfiles is None) and hostname:


### PR DESCRIPTION
add a new parameter skipdiskcopy as when boot_from_volume we won't rely
on unpackdiskimage to do disk copy.
when skipdiskcopy is False, image_name is the name of image as original.
when True, image_name will be used as the os_version which will be
used to update the guest database table.

Signed-off-by: dyyang <dyyang@cn.ibm.com>