### PR TITLE
[1.5.n] Fix error info in zthinshellutils

### DIFF
--- a/zthin-parts/zthin/lib/zthinshellutils
+++ b/zthin-parts/zthin/lib/zthinshellutils
@@ -447,7 +447,7 @@ function chccwdevDevice {
   chccwdev $opt $device &> /dev/null
   local rc=$?
   if [[ $rc -ne 0 ]]; then
-    inform "Attempt to set device offline failed. Retrying..." 1>&2
+    inform "Attempt to set device $englishOpt failed and return code is $rc. Retrying..." 1>&2
     # retry, while waiting various durations
     for seconds in $sleepTimes; do
       sleep $seconds


### PR DESCRIPTION
Currently, zthinlog always displays "set device offline failed".
This log should check parameter when displaying log info, etc "online"
or "offline".

Signed-off-by: changzhi <changzhi1990@gmail.com>