### PR TITLE
[Master]support bootable volume attach

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -1084,6 +1084,12 @@ mount_point:
   in: body
   required: false
   type: string
+root_volume:
+  description: |
+    Volume is bootable or not
+  in: body
+  required: false
+  type: bool
 disk_list_output:
   description: |
     A list of created disks info for the guest

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -303,7 +303,7 @@ Attach volume to a vm in z/VM
   - os_version: guest_os_version
   - multipath: guest_multipath
   - mount_point: mount_point
-  - boot_from_volume: root_volume
+  - is_root_volume: root_volume
 
 
 * Request sample:
@@ -339,7 +339,7 @@ Detach volume from a vm in z/VM
   - os_version: guest_os_version
   - multipath: guest_multipath
   - mount_point: mount_point
-  - boot_from_volume: root_volume
+  - is_root_volume: root_volume
 
 
 * Request sample:

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -303,6 +303,7 @@ Attach volume to a vm in z/VM
   - os_version: guest_os_version
   - multipath: guest_multipath
   - mount_point: mount_point
+  - boot_from_volume: root_volume
 
 
 * Request sample:
@@ -338,6 +339,7 @@ Detach volume from a vm in z/VM
   - os_version: guest_os_version
   - multipath: guest_multipath
   - mount_point: mount_point
+  - boot_from_volume: root_volume
 
 
 * Request sample:

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -489,7 +489,7 @@ connection_info = {
         'os_version': os_version,
         'multipath': boolean,
         'mount_point': {'type': 'string'},
-        'boot_from_volume': boolean,
+        'is_root_volume': boolean,
     },
     'required': ['assigner_id', 'zvm_fcp', 'target_wwpn',
                  'target_lun', 'multipath', 'os_version',

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -489,6 +489,7 @@ connection_info = {
         'os_version': os_version,
         'multipath': boolean,
         'mount_point': {'type': 'string'},
+        'boot_from_volume': boolean,
     },
     'required': ['assigner_id', 'zvm_fcp', 'target_wwpn',
                  'target_lun', 'multipath', 'os_version',

--- a/zvmsdk/tests/fvt/api_templates/test_volume_attach_detach.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_volume_attach_detach.tpl
@@ -10,6 +10,7 @@
         "os_version": "redhat7",
         "multipath": True,
         "mount_point": "/dev/sdz",
+        "boot_from_volume": False
       }
   }
 }

--- a/zvmsdk/tests/fvt/api_templates/test_volume_attach_detach.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_volume_attach_detach.tpl
@@ -10,7 +10,7 @@
         "os_version": "redhat7",
         "multipath": True,
         "mount_point": "/dev/sdz",
-        "boot_from_volume": False
+        "is_root_volume": False
       }
   }
 }

--- a/zvmsdk/tests/fvt/test_volume.py
+++ b/zvmsdk/tests/fvt/test_volume.py
@@ -166,7 +166,7 @@ class VolumeTestCase(base.ZVMConnectorBaseTestCase):
                            'target_wwpn': CONF.tests.target_wwpn,
                            'target_lun': CONF.tests.target_lun,
                            'mount_point': CONF.tests.mount_point,
-                           'boot_from_volume': True}
+                           'is_root_volume': True}
         # attach volume
         resp = self.client.volume_attach(connection_info)
         time.sleep(10)

--- a/zvmsdk/tests/fvt/test_volume.py
+++ b/zvmsdk/tests/fvt/test_volume.py
@@ -155,3 +155,23 @@ class VolumeTestCase(base.ZVMConnectorBaseTestCase):
         self.assertEqual(404, resp.status_code)
         resp = self.client.volume_detach(connection_info)
         self.assertEqual(404, resp.status_code)
+
+    @parameterized.expand(TEST_USERID_LIST)
+    def test_attach_detach_bootable_volume(self, case_name, userid, os_version):
+        # prepare connection_info
+        connection_info = {'assigner_id': userid,
+                           'zvm_fcp': CONF.tests.zvm_fcp,
+                           'os_version': os_version,
+                           'multipath': True,
+                           'target_wwpn': CONF.tests.target_wwpn,
+                           'target_lun': CONF.tests.target_lun,
+                           'mount_point': CONF.tests.mount_point,
+                           'boot_from_volume': True}
+        # attach volume
+        resp = self.client.volume_attach(connection_info)
+        time.sleep(10)
+        self.assertEqual(200, resp.status_code)
+        # detach volume
+        resp = self.client.volume_detach(connection_info)
+        time.sleep(10)
+        self.assertEqual(200, resp.status_code)

--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -596,6 +596,8 @@ class TestFCPVolumeManager(base.SDKTestCase):
 
         try:
             self.volumeops.attach(connection_info)
+            self.assertFalse(mock_dedicate.called)
+            self.assertFalse(mock_add_disk.called)
         finally:
             self.db_op.delete('c123')
             self.db_op.delete('d123')
@@ -831,6 +833,8 @@ class TestFCPVolumeManager(base.SDKTestCase):
 
         try:
             self.volumeops.detach(connection_info)
+            self.assertFalse(mock_undedicate.called)
+            self.assertFalse(mock_remove_disk.called)
         finally:
             self.db_op.delete('183c')
             self.db_op.delete('283c')

--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -568,7 +568,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
     def test_root_volume_attach(self, mock_dedicate, mock_add_disk, mock_check,
                                 mock_fcp_info):
 
-        connection_info = {'platform': 'x86_64',
+        connection_info = {'platform': 's390x',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
                            'multipath': 'false',
@@ -578,7 +578,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
                            'zvm_fcp': ['c123', 'd123'],
                            'mount_point': '/dev/sdz',
                            'assigner_id': 'user1',
-                           'boot_from_volume': True}
+                           'is_root_volume': True}
         fcp_list = ['opnstk1: FCP device number: C123',
                     'opnstk1:   Status: Free',
                     'opnstk1:   NPIV world wide port number: 20076D8500005182',
@@ -798,7 +798,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
     def test_root_volume_detach(self, mock_undedicate, mock_remove_disk, mock_check,
                                 mock_fcp_info):
 
-        connection_info = {'platform': 'x86_64',
+        connection_info = {'platform': 's390x',
                            'ip': '1.2.3.4',
                            'os_version': 'rhel7',
                            'multipath': 'True',
@@ -808,7 +808,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
                            'zvm_fcp': ['183c', '283c'],
                            'mount_point': '/dev/sdz',
                            'assigner_id': 'user1',
-                           'boot_from_volume': True}
+                           'is_root_volume': True}
         fcp_list = ['opnstk1: FCP device number: 183C',
                     'opnstk1:   Status: Free',
                     'opnstk1:   NPIV world wide port number: 20076D8500005182',

--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -565,6 +565,45 @@ class TestFCPVolumeManager(base.SDKTestCase):
     @mock.patch("zvmsdk.utils.check_userid_exist")
     @mock.patch("zvmsdk.volumeop.FCPVolumeManager._add_disk")
     @mock.patch("zvmsdk.volumeop.FCPVolumeManager._dedicate_fcp")
+    def test_root_volume_attach(self, mock_dedicate, mock_add_disk, mock_check,
+                                mock_fcp_info):
+
+        connection_info = {'platform': 'x86_64',
+                           'ip': '1.2.3.4',
+                           'os_version': 'rhel7',
+                           'multipath': 'false',
+                           'target_wwpn': ['20076D8500005182',
+                                           '20076D8500005183'],
+                           'target_lun': '2222',
+                           'zvm_fcp': ['c123', 'd123'],
+                           'mount_point': '/dev/sdz',
+                           'assigner_id': 'user1',
+                           'boot_from_volume': True}
+        fcp_list = ['opnstk1: FCP device number: C123',
+                    'opnstk1:   Status: Free',
+                    'opnstk1:   NPIV world wide port number: 20076D8500005182',
+                    'opnstk1:   Channel path ID: 59',
+                    'opnstk1:   Physical world wide port number: 20076D8500005181',
+                    'opnstk1: FCP device number: D123',
+                    'opnstk1:   Status: Active',
+                    'opnstk1:   NPIV world wide port number: 20076D8500005183',
+                    'opnstk1:   Channel path ID: 50',
+                    'opnstk1:   Physical world wide port number: 20076D8500005185']
+        mock_fcp_info.return_value = fcp_list
+        self.db_op = database.FCPDbOperator()
+        self.db_op.new('c123', 0)
+        self.db_op.new('d123', 1)
+
+        try:
+            self.volumeops.attach(connection_info)
+        finally:
+            self.db_op.delete('c123')
+            self.db_op.delete('d123')
+
+    @mock.patch("zvmsdk.volumeop.FCPManager._get_all_fcp_info")
+    @mock.patch("zvmsdk.utils.check_userid_exist")
+    @mock.patch("zvmsdk.volumeop.FCPVolumeManager._add_disk")
+    @mock.patch("zvmsdk.volumeop.FCPVolumeManager._dedicate_fcp")
     def test_attach_no_dedicate(self, mock_dedicate, mock_add_disk,
                                 mock_check, mock_fcp_info):
 
@@ -748,6 +787,50 @@ class TestFCPVolumeManager(base.SDKTestCase):
                                                          wwpns,
                                                          '2222', True, 'rhel7',
                                                          '/dev/sdz', 0)])
+        finally:
+            self.db_op.delete('183c')
+            self.db_op.delete('283c')
+
+    @mock.patch("zvmsdk.volumeop.FCPManager._get_all_fcp_info")
+    @mock.patch("zvmsdk.utils.check_userid_exist")
+    @mock.patch("zvmsdk.volumeop.FCPVolumeManager._remove_disk")
+    @mock.patch("zvmsdk.volumeop.FCPVolumeManager._undedicate_fcp")
+    def test_root_volume_detach(self, mock_undedicate, mock_remove_disk, mock_check,
+                                mock_fcp_info):
+
+        connection_info = {'platform': 'x86_64',
+                           'ip': '1.2.3.4',
+                           'os_version': 'rhel7',
+                           'multipath': 'True',
+                           'target_wwpn': ['20076D8500005182',
+                                           '20076D8500005183'],
+                           'target_lun': '2222',
+                           'zvm_fcp': ['183c', '283c'],
+                           'mount_point': '/dev/sdz',
+                           'assigner_id': 'user1',
+                           'boot_from_volume': True}
+        fcp_list = ['opnstk1: FCP device number: 183C',
+                    'opnstk1:   Status: Free',
+                    'opnstk1:   NPIV world wide port number: 20076D8500005182',
+                    'opnstk1:   Channel path ID: 59',
+                    'opnstk1:   Physical world wide port number: 20076D8500005181',
+                    'opnstk1: FCP device number: 283C',
+                    'opnstk1:   Status: Active',
+                    'opnstk1:   NPIV world wide port number: 20076D8500005183',
+                    'opnstk1:   Channel path ID: 50',
+                    'opnstk1:   Physical world wide port number: 20076D8500005185']
+        mock_fcp_info.return_value = fcp_list
+        mock_check.return_value = True
+        self.db_op = database.FCPDbOperator()
+        self.db_op.new('183c', 0)
+        self.db_op.assign('183c', 'USER1')
+
+        self.db_op.new('283c', 1)
+        # assign will set the connections to 1
+        self.db_op.assign('283c', 'USER1')
+
+        try:
+            self.volumeops.detach(connection_info)
         finally:
             self.db_op.delete('183c')
             self.db_op.delete('283c')

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -555,7 +555,8 @@ class FCPVolumeManager(object):
                                       mount_point, new)
 
     def _attach(self, fcp, assigner_id, target_wwpns, target_lun,
-                multipath, os_version, mount_point, path_count):
+                multipath, os_version, mount_point, path_count,
+                boot_from_volume):
         """Attach a volume
 
         First, we need translate fcp into local wwpn, then
@@ -567,6 +568,9 @@ class FCPVolumeManager(object):
         # but no assinger_id in contructor
         self.fcp_mgr.init_fcp(assigner_id)
         new = self.fcp_mgr.add_fcp_for_assigner(path_count, fcp, assigner_id)
+        if boot_from_volume:
+            LOG.info('Attaching device to %s is done.' % assigner_id)
+            return
         try:
             if new:
                 self._dedicate_fcp(fcp, assigner_id)
@@ -619,9 +623,11 @@ class FCPVolumeManager(object):
             multipath = False
         os_version = connection_info['os_version']
         mount_point = connection_info['mount_point']
+        boot_from_volume = connection_info.get('boot_from_volume', False)
 
         # TODO: check exist in db?
-        if not zvmutils.check_userid_exist(assigner_id):
+        if boot_from_volume is False and \
+                not zvmutils.check_userid_exist(assigner_id):
             LOG.error("User directory '%s' does not exist." % assigner_id)
             raise exception.SDKObjectNotExistError(
                     obj_desc=("Guest '%s'" % assigner_id), modID='volume')
@@ -631,7 +637,7 @@ class FCPVolumeManager(object):
             for i in range(path_count):
                 self._attach(fcp[i].lower(), assigner_id, target_wwpns,
                              target_lun, multipath, os_version, mount_point,
-                             path_count)
+                             path_count, boot_from_volume)
 
     def _undedicate_fcp(self, fcp, assigner_id):
         self._smtclient.undedicate_device(assigner_id, fcp)
@@ -643,10 +649,13 @@ class FCPVolumeManager(object):
                                       mount_point, connections)
 
     def _detach(self, fcp, assigner_id, target_wwpns, target_lun,
-                multipath, os_version, mount_point):
+                multipath, os_version, mount_point, boot_from_volume):
         """Detach a volume from a guest"""
         LOG.info('Start to detach device from %s' % assigner_id)
         connections = self.fcp_mgr.decrease_fcp_usage(fcp, assigner_id)
+        if boot_from_volume:
+            LOG.info('Detaching device to %s is done.' % assigner_id)
+            return
 
         try:
             self._remove_disk(fcp, assigner_id, target_wwpns, target_lun,
@@ -682,7 +691,10 @@ class FCPVolumeManager(object):
             multipath = True
         else:
             multipath = False
-        if not zvmutils.check_userid_exist(assigner_id):
+
+        boot_from_volume = connection_info.get('boot_from_volume', False)
+        if boot_from_volume is False and \
+                not zvmutils.check_userid_exist(assigner_id):
             LOG.error("Guest '%s' does not exist" % assigner_id)
             raise exception.SDKObjectNotExistError(
                     obj_desc=("Guest '%s'" % assigner_id), modID='volume')
@@ -691,7 +703,8 @@ class FCPVolumeManager(object):
             path_count = len(fcp)
             for i in range(path_count):
                 self._detach(fcp[i].lower(), assigner_id, target_wwpns,
-                             target_lun, multipath, os_version, mount_point)
+                             target_lun, multipath, os_version, mount_point,
+                             boot_from_volume)
 
     def get_volume_connector(self, assigner_id):
         """Get connector information of the instance for attaching to volumes.

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -654,7 +654,7 @@ class FCPVolumeManager(object):
         LOG.info('Start to detach device from %s' % assigner_id)
         connections = self.fcp_mgr.decrease_fcp_usage(fcp, assigner_id)
         if is_root_volume:
-            LOG.info('Detaching device to %s is done.' % assigner_id)
+            LOG.info('Detaching device from %s is done.' % assigner_id)
             return
 
         try:
@@ -673,7 +673,7 @@ class FCPVolumeManager(object):
                                multipath, os_version, mount_point, new)
             raise exception.SDKBaseException(msg=errmsg)
 
-        LOG.info('Detaching device to %s is done.' % assigner_id)
+        LOG.info('Detaching device from %s is done.' % assigner_id)
 
     def detach(self, connection_info):
         """Detach a volume from a guest


### PR DESCRIPTION
This PR is used to update FCP table record about  FCP allocation when create an instance that boot from volume. We can only create one instance on the same compute host if we don't record instance's FCP allocation.