### PR TITLE
[1.5.n] support bootable volume attach

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -1084,6 +1084,12 @@ mount_point:
   in: body
   required: false
   type: string
+root_volume:
+  description: |
+    Volume is bootable or not
+  in: body
+  required: false
+  type: bool
 disk_list_output:
   description: |
     A list of created disks info for the guest

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -303,6 +303,7 @@ Attach volume to a vm in z/VM
   - os_version: guest_os_version
   - multipath: guest_multipath
   - mount_point: mount_point
+  - is_root_volume: root_volume
 
 
 * Request sample:
@@ -338,6 +339,7 @@ Detach volume from a vm in z/VM
   - os_version: guest_os_version
   - multipath: guest_multipath
   - mount_point: mount_point
+  - is_root_volume: root_volume
 
 
 * Request sample:

--- a/zvmsdk/sdkwsgi/validation/parameter_types.py
+++ b/zvmsdk/sdkwsgi/validation/parameter_types.py
@@ -489,6 +489,7 @@ connection_info = {
         'os_version': os_version,
         'multipath': boolean,
         'mount_point': {'type': 'string'},
+        'is_root_volume': boolean,
     },
     'required': ['assigner_id', 'zvm_fcp', 'target_wwpn',
                  'target_lun', 'multipath', 'os_version',

--- a/zvmsdk/tests/fvt/api_templates/test_volume_attach_detach.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_volume_attach_detach.tpl
@@ -10,6 +10,7 @@
         "os_version": "redhat7",
         "multipath": True,
         "mount_point": "/dev/sdz",
+        "is_root_volume": False
       }
   }
 }

--- a/zvmsdk/tests/fvt/test_volume.py
+++ b/zvmsdk/tests/fvt/test_volume.py
@@ -155,3 +155,23 @@ class VolumeTestCase(base.ZVMConnectorBaseTestCase):
         self.assertEqual(404, resp.status_code)
         resp = self.client.volume_detach(connection_info)
         self.assertEqual(404, resp.status_code)
+
+    @parameterized.expand(TEST_USERID_LIST)
+    def test_attach_detach_bootable_volume(self, case_name, userid, os_version):
+        # prepare connection_info
+        connection_info = {'assigner_id': userid,
+                           'zvm_fcp': CONF.tests.zvm_fcp,
+                           'os_version': os_version,
+                           'multipath': True,
+                           'target_wwpn': CONF.tests.target_wwpn,
+                           'target_lun': CONF.tests.target_lun,
+                           'mount_point': CONF.tests.mount_point,
+                           'is_root_volume': True}
+        # attach volume
+        resp = self.client.volume_attach(connection_info)
+        time.sleep(10)
+        self.assertEqual(200, resp.status_code)
+        # detach volume
+        resp = self.client.volume_detach(connection_info)
+        time.sleep(10)
+        self.assertEqual(200, resp.status_code)

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -555,7 +555,8 @@ class FCPVolumeManager(object):
                                       mount_point, new)
 
     def _attach(self, fcp, assigner_id, target_wwpns, target_lun,
-                multipath, os_version, mount_point, path_count):
+                multipath, os_version, mount_point, path_count,
+                is_root_volume):
         """Attach a volume
 
         First, we need translate fcp into local wwpn, then
@@ -567,6 +568,9 @@ class FCPVolumeManager(object):
         # but no assinger_id in contructor
         self.fcp_mgr.init_fcp(assigner_id)
         new = self.fcp_mgr.add_fcp_for_assigner(path_count, fcp, assigner_id)
+        if is_root_volume:
+            LOG.info('Attaching device to %s is done.' % assigner_id)
+            return
         try:
             if new:
                 self._dedicate_fcp(fcp, assigner_id)
@@ -619,9 +623,11 @@ class FCPVolumeManager(object):
             multipath = False
         os_version = connection_info['os_version']
         mount_point = connection_info['mount_point']
+        is_root_volume = connection_info.get('is_root_volume', False)
 
         # TODO: check exist in db?
-        if not zvmutils.check_userid_exist(assigner_id):
+        if is_root_volume is False and \
+                not zvmutils.check_userid_exist(assigner_id):
             LOG.error("User directory '%s' does not exist." % assigner_id)
             raise exception.SDKObjectNotExistError(
                     obj_desc=("Guest '%s'" % assigner_id), modID='volume')
@@ -631,7 +637,7 @@ class FCPVolumeManager(object):
             for i in range(path_count):
                 self._attach(fcp[i].lower(), assigner_id, target_wwpns,
                              target_lun, multipath, os_version, mount_point,
-                             path_count)
+                             path_count, is_root_volume)
 
     def _undedicate_fcp(self, fcp, assigner_id):
         self._smtclient.undedicate_device(assigner_id, fcp)
@@ -643,10 +649,13 @@ class FCPVolumeManager(object):
                                       mount_point, connections)
 
     def _detach(self, fcp, assigner_id, target_wwpns, target_lun,
-                multipath, os_version, mount_point):
+                multipath, os_version, mount_point, is_root_volume):
         """Detach a volume from a guest"""
         LOG.info('Start to detach device from %s' % assigner_id)
         connections = self.fcp_mgr.decrease_fcp_usage(fcp, assigner_id)
+        if is_root_volume:
+            LOG.info('Detaching device from %s is done.' % assigner_id)
+            return
 
         try:
             self._remove_disk(fcp, assigner_id, target_wwpns, target_lun,
@@ -664,7 +673,7 @@ class FCPVolumeManager(object):
                                multipath, os_version, mount_point, new)
             raise exception.SDKBaseException(msg=errmsg)
 
-        LOG.info('Detaching device to %s is done.' % assigner_id)
+        LOG.info('Detaching device from %s is done.' % assigner_id)
 
     def detach(self, connection_info):
         """Detach a volume from a guest
@@ -682,7 +691,10 @@ class FCPVolumeManager(object):
             multipath = True
         else:
             multipath = False
-        if not zvmutils.check_userid_exist(assigner_id):
+        is_root_volume = connection_info.get('is_root_volume', False)
+
+        if is_root_volume is False and \
+                not zvmutils.check_userid_exist(assigner_id):
             LOG.error("Guest '%s' does not exist" % assigner_id)
             raise exception.SDKObjectNotExistError(
                     obj_desc=("Guest '%s'" % assigner_id), modID='volume')
@@ -691,7 +703,8 @@ class FCPVolumeManager(object):
             path_count = len(fcp)
             for i in range(path_count):
                 self._detach(fcp[i].lower(), assigner_id, target_wwpns,
-                             target_lun, multipath, os_version, mount_point)
+                             target_lun, multipath, os_version, mount_point,
+                             is_root_volume)
 
     def get_volume_connector(self, assigner_id):
         """Get connector information of the instance for attaching to volumes.


### PR DESCRIPTION
This PR is used to update FCP table record about FCP allocation when create an instance that boot from volume. We can only create one instance on the same compute host if we don't record instance's FCP allocation.