### PR TITLE
[master] RHCOS FCP support, able to boot from volume

### DIFF
--- a/doc/source/errcode.csv
+++ b/doc/source/errcode.csv
@@ -17,6 +17,7 @@
 300;10;300;11;Failed to live resize memory of guest: '%(userid)s', error: define standby memory failed with smt error: '%(err)s'.
 300;10;300;12;Failed to deploy image to userid: '%(userid)s', get unpackdiskimage cmd failed: %(err)s
 300;10;300;13;Failed to deploy image to userid: '%(userid)s', ignition file is required when deploying RHCOS image
+300;10;300;14;Failed to deploy image to userid: '%(userid)s', %(msg)s
 **Operation on Network failed**
 300;20;300;1;Database operation failed, error: %(msg)s
 300;20;300;2;ZVMSDK network error: %(msg)s

--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -1162,3 +1162,10 @@ ip_version:
   in: body
   required: true
   type: string
+skipzipl:
+  description: |
+    whether or not to skip the step of refresh bootmap. If true, only return the valid wwpn list.
+    Default value is False.
+  in: body
+  required: false
+  type: bool

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -367,6 +367,7 @@ Refresh a volume's bootmap info.
   - fcpchannel: fcp_list
   - wwpn: wwpn_list
   - lun: lun
+  - skipzipl: skipzipl
 
 * Request sample:
 

--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -86,6 +86,7 @@ function parseArgs {
   isOption -f --fcpchannel "   FCP channel IDs. Support multi fcpchannel, split by ','."
   isOption -w --wwpn "         World Wide Port Name IDs. Support multi wwpn, split by ',' Example: 5005076802400c1b"
   isOption -l --lun "          Logical Unit Number ID. Example: 0000000000000000"
+  isOption -s --skipzipl "     Whether skip ZIPL, if YES, only return physical World Wide Port Name IDs"
 
   if [[ $printHelp ]]; then
     printHelp
@@ -109,6 +110,10 @@ function parseArgs {
       ;;
       -l|--lun=*)
       lun="${i#*=}"
+      shift # past argument=value
+      ;;
+      -s|--skipzipl=*)
+      skipzipl="${i#*=}"
       shift # past argument=value
       ;;
       --default)
@@ -173,6 +178,11 @@ function refreshZIPL {
   if [[ ! -e "$devNode" ]]; then
     printError "devNode ${devNode} doesn't exist. Get fcps: ${fcps[*]} and wwpns: ${wwpns[*]}"
     exit 6
+  fi
+  
+  if [[ $skipzipl = 'YES'  ]]; then
+    inform "WWPNs: ${wwpns[*]}"
+    return
   fi
 
   # Create a mount dir.

--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -70,16 +70,24 @@ function parseArgs {
     getPositionalArg 5 diskType
     getPositionalArg 6 nicID
     getPositionalArg 7 ipConfig
+
+    # Set fcp channel and make channel lower case
+    if [[ $diskType = 'SCSI' ]]; then
+      fcpChannel=$(echo ${channelID} | tr '[:upper:]' '[:lower:]')
+    fi
   elif [[ ${#args[@]} == 6 ]]; then
     getPositionalArg 1 fcpChannel
-    getPositionalArg 2 imageFile
-    getPositionalArg 3 ignitionUrl
-    getPositionalArg 4 diskType
+    getPositionalArg 2 wwpn
+    getPositionalArg 3 lun
+    getPositionalArg 4 ignitionUrl
     getPositionalArg 5 nicID
     getPositionalArg 6 ipConfig
-
+    diskType='SCSI'
+    skipcopy='YES'
     # Make channel, WWPN, and LUN lower case
     fcpChannel=$(echo ${fcpChannel} | tr '[:upper:]' '[:lower:]')
+    wwpn=$(echo ${wwpn} | tr '[:upper:]' '[:lower:]')
+    lun=$(echo ${lun} | tr '[:upper:]' '[:lower:]')
   else
     getPositionalArg 1 userID
     getPositionalArg 2 channelID
@@ -109,7 +117,7 @@ function parseArgs {
     echo 'ERROR: Missing required parameter.'
     printCMDUsage
     exit 1
-  elif [[ ${#args[@]} == 6 && (! $fcpChannel || ! $imageFile || ! $ignitionUrl || ! $diskType || ! $nicID || ! $ipConfig) ]]; then
+  elif [[ ${#args[@]} == 6 && (! $fcpChannel || ! $wwpn || ! $lun || ! $ignitionUrl || ! $nicID || ! $ipConfig) ]]; then
     echo 'ERROR: Missing required parameter.'
     printCMDUsage
     exit 1
@@ -151,7 +159,7 @@ function parseArgs {
     echo "LUN:            \"$lun\""
     echo "IMAGE FILE:     \"$imageFile\""
     echo ""
-  elif [[ ${#args[@]} == 7 ]]; then
+  elif [[ ${#args[@]} == 7 && $diskType = 'ECKD']]; then
     echo "SOURCE USER ID: \"$userID\""
     echo "DISK CHANNEL:   \"$channelID\""
     echo "IMAGE FILE:     \"$imageFile\""
@@ -160,9 +168,18 @@ function parseArgs {
     echo "NIC ID:         \"$nicID\""
     echo "IP config:      \"$ipConfig\""
     echo ""
-  elif [[ ${#args[@]} == 6 ]]; then
+  elif [[ ${#args[@]} == 7 && $diskType = 'SCSI' ]]; then
     echo "FCP CHANNEL:    \"$fcpChannel\""
     echo "IMAGE FILE:     \"$imageFile\""
+    echo "IGNITION URL:   \"$ignitionUrl\""
+    echo "DISK TYPE:      \"$diskType\""
+    echo "NIC ID:         \"$nicID\""
+    echo "IP config:      \"$ipConfig\""
+    echo ""
+  elif [[ ${#args[@]} == 6 ]]; then
+    echo "FCP CHANNEL:    \"$fcpChannel\""
+    echo "WWPN:           \"$wwpn\""
+    echo "LUN:            \"$lun\""
     echo "IGNITION URL:   \"$ignitionUrl\""
     echo "DISK TYPE:      \"$diskType\""
     echo "NIC ID:         \"$nicID\""
@@ -186,7 +203,7 @@ function checkSanity {
   #   be expected.
   # @Code:
   # Make sure the specified image file exists.
-  if [[ ! -f $imageFile ]]; then
+  if [[ $skipcopy != 'YES' && ! -f $imageFile ]]; then
     printError 'The specified image file was not found.'
     exit 3
   fi
@@ -1154,6 +1171,21 @@ EOF
     # @Description:
     #   Deploy the specified SCSI disk image.
     # @Code:
+    if [[ $skipcopy = 'YES' ]]; then
+      connectFcp $fcpChannel $wwpn $lun
+      if (( $? )); then
+        printError "Failed to connect SCSI disk:${fcpChannel}"
+        exit 3
+      fi
+      local DEST_DEV=`ls -al /dev/disk/by-path/ccw-0.0.${fcpChannel}-zfcp-${wwpn}:${lun} | tr '/' ' ' | awk '{print \$NF}'`
+      DEST_DEV=/dev/$DEST_DEV
+      # Update bootloader records
+      update_zipl_bootloader_fcp
+
+      inform "Install complete"
+      return
+    fi
+
     dedicateFcp $fcpChannel
     if (( $? )); then
       printError "Failed to connect SCSI disk:${fcpChannel}"
@@ -1164,37 +1196,9 @@ EOF
     lun=$(ls /dev/disk/by-path/ |grep -E ccw-0.0.${fcpChannel}-zfcp-|cut -d "-" -f 4 |tail -n 1 |cut -d ":" -f 2)
     local DEST_DEV=`ls -al /dev/disk/by-path/ccw-0.0.${fcpChannel}-zfcp-${wwpn}:${lun} | tr '/' ' ' | awk '{print \$NF}'`
     DEST_DEV=/dev/$DEST_DEV
-    # store the imageinfo to a file
-    mkdir -p /tmp/${fcpChannel}
-    sfdisk -d $imageFile >/tmp/${fcpChannel}/image.info
-    (while IFS='\n' read -r line || [ -n "$line" ]
-    do
-        if [[ $line =~ "start=" ]]
-        then
-            # we save the start= and size= here, then dd the partitions later
-            printf "%s:%s\n" \
-                "$(echo $line | cut -d: -f 2 | cut -d, -f 1 | tr -d ' ')" \
-                "$(echo $line | cut -d: -f 2 | cut -d, -f 2 | tr -d ' ')" \
-                >> /tmp/${fcpChannel}/sfdisk_info
-        elif ! [[ $line =~ "label:" || $line =~ "label-id:" || $line =~ "unit:" ]]
-        then
-            continue
-        fi
-        echo $line
-    done < /tmp/${fcpChannel}/image.info
-    ) | sfdisk "${DEST_DEV}"
 
     inform "Copy partition..."
-    while IFS='' read -r line || [ -n "$line" ]
-    do
-        eval ${line%%:*} ${line##*:}
-        dd if=${imageFile} bs=512 iflag=fullblock \
-            of="${DEST_DEV}" status=progress skip=$start seek=$start count=$size
-        if [[ $? -ne 0 ]]; then
-            log "failed to write image to zFCP SCSI disk"
-            exit 1
-        fi
-    done < /tmp/${fcpChannel}/sfdisk_info
+    dd if=${imageFile} bs=512 iflag=fullblock of="${DEST_DEV}" status=progress
 
     # Update bootloader records
     update_zipl_bootloader_fcp
@@ -1266,13 +1270,13 @@ function cleanup {
   fi
 
   # Make sure we've released our connection to the target disk.
-  if [[ $userID ]]; then
+  if [[ $userID && ! $fcpChannel]]; then
     disconnectDisk $userID $channelID 0
     if [[ $diskType ]]; then
       rm -rf /tmp/${userID}
     fi
   else
-    if [[ $diskType ]]; then
+    if [[ $diskType && ! $skipcopy]]; then
       undedicateFcp ${fcpChannel} ${wwpn} ${lun}
       rm -rf /tmp/${fcpChannel}
     else

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -396,11 +396,13 @@ def req_volume_refresh_bootmap(start_index, *args, **kwargs):
     fcpchannel = kwargs.get('fcpchannels', None)
     wwpn = kwargs.get('wwpn', None)
     lun = kwargs.get('lun', None)
+    skipzipl = kwargs.get('skipzipl', False)
     body = {'info':
         {
             "fcpchannel": fcpchannel,
             "wwpn": wwpn,
             "lun": lun,
+            "skipzipl": skipzipl,
         }
     }
     fill_kwargs_in_body(body['info'], **kwargs)

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1418,14 +1418,16 @@ class SDKAPI(object):
         """
         self._volumeop.attach_volume_to_instance(connection_info)
 
-    def volume_refresh_bootmap(self, fcpchannels, wwpns, lun):
+    def volume_refresh_bootmap(self, fcpchannels, wwpns, lun, skipzipl=False):
         """ Refresh a volume's bootmap info.
 
         :param list of fcpchannels
         :param list of wwpns
         :param string lun
+        :param boolean skipzipl: whether ship zipl, only return physical wwpns
         """
-        return self._volumeop.volume_refresh_bootmap(fcpchannels, wwpns, lun)
+        return self._volumeop.volume_refresh_bootmap(fcpchannels, wwpns, lun,
+                                                     skipzipl=skipzipl)
 
     def volume_detach(self, connection_info):
         """ Detach a volume from a guest. It's prerequisite to active multipath

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -169,6 +169,7 @@ errors = {
                    "get unpackdiskimage cmd failed: %(err)s"),
                13: ("Failed to deploy image to userid: '%(userid)s', "
                    "ignition file is required when deploying RHCOS image"),
+               14: ("Failed to deploy image to userid: '%(userid)s', %(msg)s")
               },
               "Operation on Guest failed"
               ],

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -60,9 +60,9 @@ class VolumeAction(object):
         conn = self.client.send_request('get_volume_connector', userid)
         return conn
 
-    def volume_refresh_bootmap(self, fcpchannel, wwpn, lun):
+    def volume_refresh_bootmap(self, fcpchannel, wwpn, lun, skipzipl):
         info = self.client.send_request('volume_refresh_bootmap',
-                                        fcpchannel, wwpn, lun)
+                                        fcpchannel, wwpn, lun, skipzipl)
         return info
 
 
@@ -113,13 +113,14 @@ def volume_detach(req):
 @tokens.validate
 def volume_refresh_bootmap(req):
 
-    def _volume_refresh_bootmap(req, fcpchannel, wwpn, lun):
+    def _volume_refresh_bootmap(req, fcpchannel, wwpn, lun, skipzipl):
         action = get_action()
-        return action.volume_refresh_bootmap(fcpchannel, wwpn, lun)
+        return action.volume_refresh_bootmap(fcpchannel, wwpn, lun, skipzipl)
 
     body = util.extract_json(req.body)
     info = _volume_refresh_bootmap(req, body['info']['fcpchannel'],
-                                   body['info']['wwpn'], body['info']['lun'])
+                                   body['info']['wwpn'], body['info']['lun'],
+                                   body['info'].get('skipzipl', False))
     info_json = json.dumps(info)
     req.response.body = utils.to_utf8(info_json)
     req.response.content_type = 'application/json'

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_volume.py
@@ -105,4 +105,4 @@ class HandlersVolumeTest(unittest.TestCase):
         volume.volume_refresh_bootmap(self.req)
         mock_detach.assert_called_once_with(
             'volume_refresh_bootmap',
-            fcpchannels, wwpns, lun)
+            fcpchannels, wwpns, lun, False)

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -275,7 +275,8 @@ class SDKAPITestCase(base.SDKTestCase):
         wwpn = ['5005076802100c1b', '5005076802200c1b']
         lun = '01000000000000'
         self.api.volume_refresh_bootmap(fcpchannel, wwpn, lun)
-        mock_attach.assert_called_once_with(fcpchannel, wwpn, lun)
+        mock_attach.assert_called_once_with(fcpchannel, wwpn, lun,
+                                            skipzipl=False)
 
     @mock.patch("zvmsdk.volumeop.VolumeOperatorAPI."
                 "detach_volume_from_instance")

--- a/zvmsdk/vmops.py
+++ b/zvmsdk/vmops.py
@@ -295,7 +295,8 @@ class VMOps(object):
                 self.set_hostname(userid, hostname, os_version)
         else:
             self._smtclient.guest_deploy_rhcos(userid, image_name,
-                            transportfiles, remotehost, vdev, hostname)
+                            transportfiles, remotehost, vdev, hostname,
+                            skipdiskcopy)
 
     def guest_capture(self, userid, image_name, capture_type='rootonly',
                       compress_level=6):

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -85,9 +85,10 @@ class VolumeOperatorAPI(object):
     def detach_volume_from_instance(self, connection_info):
         self._volume_manager.detach(connection_info)
 
-    def volume_refresh_bootmap(self, fcpchannel, wwpn, lun):
+    def volume_refresh_bootmap(self, fcpchannel, wwpn, lun, skipzipl=False):
         return self._volume_manager.volume_refresh_bootmap(fcpchannel,
-                                                           wwpn, lun)
+                                                           wwpn, lun,
+                                                           skipzipl=skipzipl)
 
     def get_volume_connector(self, assigner_id):
         return self._volume_manager.get_volume_connector(assigner_id)
@@ -590,14 +591,16 @@ class FCPVolumeManager(object):
 
         LOG.info('Attaching device to %s is done.' % assigner_id)
 
-    def volume_refresh_bootmap(self, fcpchannels, wwpns, lun):
+    def volume_refresh_bootmap(self, fcpchannels, wwpns, lun, skipzipl=False):
         """ Refresh a volume's bootmap info.
 
         :param list of fcpchannels
         :param list of wwpns
         :param string lun
+        :param boolean skipzipl: whether ship zipl, only return physical wwpns
         """
-        return self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns, lun)
+        return self._smtclient.volume_refresh_bootmap(fcpchannels, wwpns, lun,
+                                                      skipzipl=skipzipl)
 
     def attach(self, connection_info):
         """Attach a volume to a guest


### PR DESCRIPTION
1. Update volume_refrsh_bootmap, support to skip zipl update,
   only return online wwpn
2. For rhcos FCP support, allow boot from volume, skip copy disk
   in unpackdiskimage

Signed-off-by: ylpan <ylpan@cn.ibm.com>