### PR TITLE
[master] guest get user direct from hypervisor for onboarding

### DIFF
--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -611,6 +611,35 @@ Get running information of guest.
    :language: javascript
 
 
+Get Guest user direct
+---------------------
+
+**GET /guests/{userid}/user_direct**
+
+Get the user directory info of the given userid from hypervisor.
+
+* Request:
+
+.. restapi_parameters:: parameters.yaml
+
+  - userid: guest_userid
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
+.. restapi_parameters:: parameters.yaml
+
+  - output: user_direct_guest
+
+* Response sample:
+
+.. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_guest_get_user_direct.tpl
+   :language: javascript
+
+
 Get Guest adapters info
 -----------------------
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -309,6 +309,12 @@ def req_guest_get_info(start_index, *args, **kwargs):
     return url, body
 
 
+def req_guest_get_user_direct(start_index, *args, **kwargs):
+    url = '/guests/%s/user_direct'
+    body = None
+    return url, body
+
+
 def req_guest_get_adapters_info(start_index, *args, **kwargs):
     url = '/guests/%s/adapters'
     body = None
@@ -695,6 +701,11 @@ DATABASE = {
         'args_required': 1,
         'params_path': 1,
         'request': req_guest_get_info},
+    'guest_get_user_direct': {
+        'method': 'GET',
+        'args_required': 1,
+        'params_path': 1,
+        'request': req_guest_get_user_direct},
     'guest_get_adapters_info': {
         'method': 'GET',
         'args_required': 1,

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -219,6 +219,34 @@ class SDKAPI(object):
         with zvmutils.log_and_reraise_sdkbase_error(action):
             return self._vmops.get_adapters_info(userid)
 
+    def guest_get_user_direct(self, userid):
+        """Get user direct of the specified guest vm
+
+        :param str userid: the user id of the guest vm
+        :returns: Dictionary describing user direct and check info result
+        :rtype: dict
+        """
+        action = "get the user direct of guest '%s'" % userid
+        with zvmutils.log_and_reraise_sdkbase_error(action):
+            inst_info = self._vmops.get_definition_info(userid)
+            user_direct = inst_info['user_direct']
+            item = -1
+            new_info = ""
+            for info in user_direct:
+                item += 1
+                # replace password with ******
+                if info.startswith('USER') or info.startswith('IDENTITY'):
+                    fields = info.split()
+                    for i in range(len(fields)):
+                        if i != 2:
+                            new_info += (fields[i] + ' ')
+                        else:
+                            new_info += ('******' + ' ')
+                    user_direct[item] = new_info
+                    break
+            inst_info['user_direct'] = user_direct
+            return inst_info
+
     def guest_list(self):
         """list names of all the VMs on this host.
 

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -73,6 +73,9 @@ ROUTE_LIST = (
     ('/guests/{userid}/info', {
         'GET': guest.guest_get_info,
     }),
+    ('/guests/{userid}/user_direct', {
+        'GET': guest.guest_get_user_direct,
+    }),
     ('/guests/{userid}/adapters', {
         'GET': guest.guest_get_adapters_info,
     }),

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -93,6 +93,11 @@ class VMHandler(object):
         return info
 
     @validation.query_schema(guest.userid_list_query)
+    def get_user_direct(self, req, userid):
+        info = self.client.send_request('guest_get_user_direct', userid)
+        return info
+
+    @validation.query_schema(guest.userid_list_query)
     def get_adapters(self, req, userid):
         info = self.client.send_request('guest_get_adapters_info', userid)
         return info
@@ -489,6 +494,26 @@ def guest_get_info(req):
 
     userid = util.wsgi_path_item(req.environ, 'userid')
     info = _guest_get_info(req, userid)
+
+    info_json = json.dumps(info)
+    req.response.status = util.get_http_code_from_sdk_return(info,
+        additional_handler=util.handle_not_found)
+    req.response.body = utils.to_utf8(info_json)
+    req.response.content_type = 'application/json'
+    return req.response
+
+
+@util.SdkWsgify
+@tokens.validate
+def guest_get_user_direct(req):
+
+    def _guest_get_user_direct(req, userid):
+        action = get_handler()
+
+        return action.get_user_direct(req, userid)
+
+    userid = util.wsgi_path_item(req.environ, 'userid')
+    info = _guest_get_user_direct(req, userid)
 
     info_json = json.dumps(info)
     req.response.status = util.get_http_code_from_sdk_return(info,

--- a/zvmsdk/tests/fvt/api_templates/test_guest_get_user_direct.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_guest_get_user_direct.tpl
@@ -1,0 +1,8 @@
+{
+    "rs": 0,
+    "overallRC": 0,
+    "modID": null,
+    "rc": 0,
+    "errmsg": "",
+    "output": {"user_direct": ["USER1", "INCLUDE PROFILE"]}
+}

--- a/zvmsdk/tests/fvt/test_guest.py
+++ b/zvmsdk/tests/fvt/test_guest.py
@@ -620,6 +620,10 @@ class GuestHandlerTestCase(GuestHandlerBase):
         self.assertEqual(200, resp.status_code)
         self.apibase.verify_result('test_guest_get_info', resp.content)
 
+        resp = self.client.guest_get_user_direct(userid)
+        self.assertEqual(200, resp.status_code)
+        self.apibase.verify_result('test_guest_get_user_direct', resp.content)
+
         resp = self.client.guest_get_power_state(userid)
         self.assertEqual(200, resp.status_code)
         self.apibase.verify_result('test_guest_get_power_state',

--- a/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
+++ b/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
@@ -400,6 +400,22 @@ class RESTClientTestCase(unittest.TestCase):
 
     @mock.patch.object(requests, 'request')
     @mock.patch('zvmconnector.restclient.RESTClient._get_token')
+    def test_guest_get_user_direct(self, get_token, request):
+        method = 'GET'
+        url = '/guests/%s/user_direct' % self.fake_userid
+        body = None
+        header = self.headers
+        full_uri = self.base_url + url
+        request.return_value = self.response
+        get_token.return_value = self._tmp_token()
+
+        self.client.call("guest_get_user_direct", self.fake_userid)
+        request.assert_called_with(method, full_uri,
+                                   data=body, headers=header,
+                                   verify=False)
+
+    @mock.patch.object(requests, 'request')
+    @mock.patch('zvmconnector.restclient.RESTClient._get_token')
     def test_guest_get_info_ssl(self, get_token, request):
         method = 'GET'
         url = '/guests/%s/info' % self.fake_userid

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
@@ -652,6 +652,14 @@ class HandlersGuestTest(SDKWSGITest):
         mock_get.assert_called_once_with(self.req, FAKE_USERID)
 
     @mock.patch.object(util, 'wsgi_path_item')
+    @mock.patch.object(guest.VMHandler, 'get_user_direct')
+    def test_guest_get_user_direct(self, mock_get, mock_userid):
+        mock_get.return_value = ''
+        mock_userid.return_value = FAKE_USERID
+
+        guest.guest_get_user_direct(self.req)
+
+    @mock.patch.object(util, 'wsgi_path_item')
     @mock.patch.object(guest.VMHandler, 'get_power_state')
     def test_guest_power_state(self, mock_get, mock_userid):
         mock_get.return_value = ''

--- a/zvmsdk/tests/unit/sdkwsgi/test_handler.py
+++ b/zvmsdk/tests/unit/sdkwsgi/test_handler.py
@@ -217,6 +217,18 @@ class GuestHandlerTest(unittest.TestCase):
             get_info.assert_called_once_with(mock.ANY, '1')
 
     @mock.patch.object(tokens, 'validate')
+    def test_guest_get_user_direct(self, mock_validate):
+        self.env['PATH_INFO'] = '/guests/1/user_direct'
+        self.env['REQUEST_METHOD'] = 'GET'
+        h = handler.SdkHandler()
+        with mock.patch('zvmsdk.sdkwsgi.handlers.guest.VMHandler.'
+                        'get_user_direct') as get_user_direct:
+            get_user_direct.return_value = {'overallRC': 0}
+            h(self.env, dummy)
+
+            get_user_direct.assert_called_once_with(mock.ANY, '1')
+
+    @mock.patch.object(tokens, 'validate')
     def test_guest_get(self, mock_validate):
         self.env['PATH_INFO'] = '/guests/1'
         self.env['REQUEST_METHOD'] = 'GET'

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -46,6 +46,18 @@ class SDKAPITestCase(base.SDKTestCase):
         self.api.guest_get_info(self.userid)
         ginfo.assert_called_once_with(self.userid)
 
+    @mock.patch("zvmsdk.vmops.VMOps.get_definition_info")
+    def test_guest_get_user_direct_(self, ginfo):
+        ginfo.return_value = {'user_direct':
+                              ['CPU 00 BASE',
+                               'USER USERID1 PASSWORD 4096m ']}
+        expected_value = {'user_direct':
+                          ['CPU 00 BASE',
+                           'USER USERID1 ****** 4096m ']}
+        result = self.api.guest_get_user_direct(self.userid)
+        ginfo.assert_called_once_with(self.userid)
+        self.assertEqual(result, expected_value)
+
     @mock.patch("zvmsdk.vmops.VMOps.get_adapters_info")
     def test_guest_get_adapters_info(self, adapters_info):
         self.api.guest_get_adapters_info(self.userid)


### PR DESCRIPTION
___________________________________ summary ____________________________________
ERROR:   pep8: commands failed
  py27: commands succeeded
  py36: commands succeeded
  docs: commands succeeded


pep8 error not related to this commit:
21392] /root/repo/python-zvm-sdk$ /root/repo/python-zvm-sdk/.tox/pep8/bin/flake8
./get-pip.py:90:5: E306 expected 1 blank line before a nested definition, found 0
./env/bin/activate_this.py:6:80: E501 line too long (97 > 79 characters)
./env/bin/activate_this.py:15:80: E501 line too long (95 > 79 characters)
./env/bin/activate_this.py:18:80: E501 line too long (103 > 79 characters)
./env/bin/activate_this.py:21:80: E501 line too long (94 > 79 characters)
./env/bin/activate_this.py:26:80: E501 line too long (95 > 79 characters)
./env/lib64/python2.7/os.py:24:1: E265 block comment should start with '# '