### PR TITLE
[master] add interfaces to get guest power state from hypervisor

### DIFF
--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -546,6 +546,37 @@ Delete a guest.
   No Response
 
 
+Get Guest power state from hypervisor
+--------------------------------------
+
+**GET /guests/{userid}/power_state_real**
+
+Get power state of the guest from hypervisor directly,
+
+no matter the guest is in zcc database or not.
+
+* Request:
+
+.. restapi_parameters:: parameters.yaml
+
+  - userid: guest_userid
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
+.. restapi_parameters:: parameters.yaml
+
+  - output: power_status_guest
+
+* Response sample:
+
+.. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_guest_get_power_state_real.tpl
+   :language: javascript
+
+
 Get Guest info
 --------------
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -297,6 +297,12 @@ def req_guest_deploy(start_index, *args, **kwargs):
     return url, body
 
 
+def req_guest_get_power_state_real(start_index, *args, **kwargs):
+    url = '/guests/%s/power_state_real'
+    body = None
+    return url, body
+
+
 def req_guest_get_info(start_index, *args, **kwargs):
     url = '/guests/%s/info'
     body = None
@@ -679,6 +685,11 @@ DATABASE = {
         'args_required': 2,
         'params_path': 1,
         'request': req_guest_deploy},
+    'guest_get_power_state_real': {
+        'method': 'GET',
+        'args_required': 1,
+        'params_path': 1,
+        'request': req_guest_get_power_state_real},
     'guest_get_info': {
         'method': 'GET',
         'args_required': 1,

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -199,6 +199,12 @@ class SDKAPI(object):
         with zvmutils.log_and_reraise_sdkbase_error(action):
             return self._vmops.get_info(userid)
 
+    def guest_get_power_state_real(self, userid):
+        """Returns power state of a virtual machine from hypervisor."""
+        action = "get power state of guest '%s' from hypervisor" % userid
+        with zvmutils.log_and_reraise_sdkbase_error(action):
+            return self._vmops.get_power_state(userid)
+
     def guest_get_adapters_info(self, userid):
         """Get the network information of a virtual machine.
         this userid may not in zCC.

--- a/zvmsdk/sdkwsgi/handler.py
+++ b/zvmsdk/sdkwsgi/handler.py
@@ -67,6 +67,9 @@ ROUTE_LIST = (
     ('/guests/{userid}/action', {
         'POST': guest.guest_action,
     }),
+    ('/guests/{userid}/power_state_real', {
+        'GET': guest.guest_get_power_state_real,
+    }),
     ('/guests/{userid}/info', {
         'GET': guest.guest_get_info,
     }),

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -83,6 +83,11 @@ class VMHandler(object):
         return info
 
     @validation.query_schema(guest.userid_list_query)
+    def get_power_state_real(self, req, userid):
+        info = self.client.send_request('guest_get_power_state_real', userid)
+        return info
+
+    @validation.query_schema(guest.userid_list_query)
     def get_info(self, req, userid):
         info = self.client.send_request('guest_get_info', userid)
         return info
@@ -453,6 +458,25 @@ def get_handler():
     if _VMHANDLER is None:
         _VMHANDLER = VMHandler()
     return _VMHANDLER
+
+
+@util.SdkWsgify
+@tokens.validate
+def guest_get_power_state_real(req):
+
+    def _guest_get_power_state_real(req, userid):
+        action = get_handler()
+        return action.get_power_state_real(req, userid)
+
+    userid = util.wsgi_path_item(req.environ, 'userid')
+    info = _guest_get_power_state_real(req, userid)
+
+    info_json = json.dumps(info)
+    req.response.status = util.get_http_code_from_sdk_return(info,
+        additional_handler=util.handle_not_found)
+    req.response.body = utils.to_utf8(info_json)
+    req.response.content_type = 'application/json'
+    return req.response
 
 
 @util.SdkWsgify

--- a/zvmsdk/tests/fvt/api_templates/test_guest_get_power_state_real.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_guest_get_power_state_real.tpl
@@ -1,0 +1,8 @@
+{
+    "rs": 0,
+    "overllRC": 0,
+    "modID": null,
+    "rc": 0,
+    "errmsg": "",
+    "output": "off"
+}

--- a/zvmsdk/tests/fvt/test_guest.py
+++ b/zvmsdk/tests/fvt/test_guest.py
@@ -607,6 +607,11 @@ class GuestHandlerTestCase(GuestHandlerBase):
         result = self._smtclient.execute_cmd(userid, 'hostname')
         self.assertIn('deploy_fvt', str(result))
 
+        resp = self.client.guest_get_power_state_real(userid)
+        self.assertEqual(200, resp.status_code)
+        self.apibase.verify_result('test_guest_get_power_state_real',
+                                   resp.content)
+
         resp = self.client.guest_get_definition_info(userid)
         self.assertEqual(200, resp.status_code)
         self.apibase.verify_result('test_guest_get', resp.content)

--- a/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
+++ b/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
@@ -623,6 +623,22 @@ class RESTClientTestCase(unittest.TestCase):
 
     @mock.patch.object(requests, 'request')
     @mock.patch('zvmconnector.restclient.RESTClient._get_token')
+    def test_guest_get_power_state_real(self, get_token, request):
+        method = 'GET'
+        url = '/guests/%s/power_state_real' % self.fake_userid
+        body = None
+        header = self.headers
+        full_uri = self.base_url + url
+        request.return_value = self.response
+        get_token.return_value = self._tmp_token()
+
+        self.client.call("guest_get_power_state_real", self.fake_userid)
+        request.assert_called_with(method, full_uri,
+                                   data=body, headers=header,
+                                   verify=False)
+
+    @mock.patch.object(requests, 'request')
+    @mock.patch('zvmconnector.restclient.RESTClient._get_token')
     def test_host_get_info(self, get_token, request):
         method = 'GET'
         url = '/host'

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
@@ -634,6 +634,15 @@ class HandlersGuestTest(SDKWSGITest):
         mock_list.assert_called_once_with()
 
     @mock.patch.object(util, 'wsgi_path_item')
+    @mock.patch.object(guest.VMHandler, 'get_power_state_real')
+    def test_guest_power_state_real(self, mock_get, mock_userid):
+        mock_get.return_value = ''
+        mock_userid.return_value = FAKE_USERID
+
+        guest.guest_get_power_state_real(self.req)
+        mock_get.assert_called_once_with(self.req, FAKE_USERID)
+
+    @mock.patch.object(util, 'wsgi_path_item')
     @mock.patch.object(guest.VMHandler, 'get_info')
     def test_guest_get_info(self, mock_get, mock_userid):
         mock_get.return_value = ''

--- a/zvmsdk/tests/unit/sdkwsgi/test_handler.py
+++ b/zvmsdk/tests/unit/sdkwsgi/test_handler.py
@@ -243,6 +243,19 @@ class GuestHandlerTest(unittest.TestCase):
             delete_nic.assert_called_once_with('1', '1000', '')
 
     @mock.patch.object(tokens, 'validate')
+    def test_guest_get_power_state_real(self, mock_validate):
+        self.env['PATH_INFO'] = '/guests/1/power_state_real'
+        self.env['REQUEST_METHOD'] = 'GET'
+        h = handler.SdkHandler()
+        func = 'zvmsdk.sdkwsgi.handlers.guest.VMHandler'\
+               '.get_power_state_real'
+        with mock.patch(func) as get_power:
+            get_power.return_value = {'overallRC': 0}
+            h(self.env, dummy)
+
+            get_power.assert_called_once_with(mock.ANY, '1')
+
+    @mock.patch.object(tokens, 'validate')
     def test_guest_get_power_state(self, mock_validate):
         self.env['PATH_INFO'] = '/guests/1/power_state'
         self.env['REQUEST_METHOD'] = 'GET'

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -36,6 +36,11 @@ class SDKAPITestCase(base.SDKTestCase):
     def test_init_ComputeAPI(self):
         self.assertTrue(isinstance(self.api, api.SDKAPI))
 
+    @mock.patch("zvmsdk.vmops.VMOps.get_power_state")
+    def test_guest_get_power_state_real(self, gstate):
+        self.api.guest_get_power_state_real(self.userid)
+        gstate.assert_called_once_with(self.userid)
+
     @mock.patch("zvmsdk.vmops.VMOps.get_info")
     def test_guest_get_info(self, ginfo):
         self.api.guest_get_info(self.userid)


### PR DESCRIPTION


___________________________________ summary ____________________________________
ERROR:   pep8: commands failed
  py27: commands succeeded
  py36: commands succeeded
  docs: commands succeeded
the pep8 error is not related to this commit
./get-pip.py:90:5: E306 expected 1 blank line before a nested definition, found 0
./env/bin/activate_this.py:6:80: E501 line too long (97 > 79 characters)
./env/bin/activate_this.py:15:80: E501 line too long (95 > 79 characters)
./env/bin/activate_this.py:18:80: E501 line too long (103 > 79 characters)
./env/bin/activate_this.py:21:80: E501 line too long (94 > 79 characters)
./env/bin/activate_this.py:26:80: E501 line too long (95 > 79 characters)
./env/lib64/python2.7/os.py:24:1: E265 block comment should start with '# '