### PR TITLE
[1.5.n] fix the keyerror exception in fcp database operation

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -271,7 +271,7 @@ class NetworkDbOperator(object):
 class FCPDbOperator(object):
 
     def __init__(self):
-        self._module_id = 'FCP'
+        self._module_id = 'volume'
         self._initialize_table()
 
     def _initialize_table(self):


### PR DESCRIPTION
'FCP' module id is not defined, should use 'volume'. Otherwise when exception happens, it would cause keyerror of 'FCP' and the exception msg would be confusing.

```
2020-03-20 04:07:06.707 23609 ERROR nova.virt.zvm.utils [req-5ddf32d8-50c3-4e83-aa2e-4fa248f611b9 0688b01e6439ca32d698d20789d52169126fb41fb1a4ddafcebb97d854e836c9 f5bd1af496f04678be0a28248af984c5 - default default] zVM Cloud Connector request volume_detach failed with parameters: ({'mount_point': u'/dev/vda', 'assigner_id': 'ydy00038', 'is_root_volume': True, 'os_version': u'Rhel8.1', 'zvm_fcp': [u'5c42', u'5d42'], 'target_lun': '0x0001000000000000', 'multipath': 'true', 'target_wwpn': [u'0x5005076802100C1B', u'0x5005076802200C1B', u'0x5005076802300C1B', u'0x5005076802400C1B', u'0x5005076802400C1A', u'0x5005076802300C1A', u'0x5005076802200C1A', u'0x5005076802100C1A']},) {} .  Results: {u'rs': 1, u'overallRC': 300, u'modID': 10, u'rc': 300, u'output': u'', u'errmsg': u"Database operation failed, error: Execute SQL statements error: 'FCP'"}: ZVMConnectorError: zVM Cloud Connector request failed: {u'rs': 1, u'overallRC': 404, u'modID': 10, u'rc': 404, u'output': u'', u'errmsg': u"Guest 'YDY00038' does not exist."}
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [req-5ddf32d8-50c3-4e83-aa2e-4fa248f611b9 0688b01e6439ca32d698d20789d52169126fb41fb1a4ddafcebb97d854e836c9 f5bd1af496f04678be0a28248af984c5 - default default] [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8] Got exception when clean up ydy00038 volumes: ZVMConnectorError: zVM Cloud Connector request failed: {u'rs': 1, u'overallRC': 300, u'modID': 10, u'rc': 300, u'output': u'', u'errmsg': u"Database operation failed, error: Execute SQL statements error: 'FCP'"}
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8] Traceback (most recent call last):
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8]   File "/usr/lib/python2.7/site-packages/nova/virt/zvm/driver.py", line 490, in clean_up
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8]     instance, root_bdm['mount_device'])
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8]   File "/usr/lib/python2.7/site-packages/nova/virt/zvm/driver.py", line 653, in detach_volume
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8]     mountpoint, encryption)
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8]   File "/usr/lib/python2.7/site-packages/nova/virt/zvm/hypervisor.py", line 317, in detach_volume
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8]     instance, mountpoint)
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8]   File "/usr/lib/python2.7/site-packages/nova/virt/zvm/hypervisor.py", line 263, in _detach_volume_from_instance
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8]     res = self._reqh.call('volume_detach', conn_info)
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8]   File "/usr/lib/python2.7/site-packages/nova/virt/zvm/utils.py", line 71, in call
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8]     raise exception.ZVMConnectorError(results=results)
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8] ZVMConnectorError: zVM Cloud Connector request failed: {u'rs': 1, u'overallRC': 300, u'modID': 10, u'rc': 300, u'output': u'', u'errmsg': u"Database operation failed, error: Execute SQL statements error: 'FCP'"}
2020-03-20 04:07:06.708 23609 ERROR nova.virt.zvm.driver [instance: e29c8cf2-4d64-4ad1-a6de-eef60d51a4d8]
```


Signed-off-by: dyyang <dyyang@cn.ibm.com>