### PR TITLE
[master] add api to extend root partition of  volume

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -387,6 +387,12 @@ action_capture_guest:
   in: body
   required: true
   type: string
+action_grow_root_volume_guest:
+  description: |
+    Take ``grow_root_volume`` action on guest.
+  in: body
+  required: true
+  type: string
 action_get_console_guest:
   description: |
     Take ``get_console_output`` action on guest.

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -1276,6 +1276,30 @@ Capture guest
 
 * Response contents:
 
+Grow root volume of guest
+-------------------------
+
+**POST /guests/{userid}/action**
+
+* Request:
+
+.. restapi_parameters:: parameters.yaml
+
+  - userid: guest_userid
+  - action: action_grow_root_volume_guest
+  - os_version: guest_os_version
+
+* Request sample:
+
+.. literalinclude:: ../../zvmsdk/tests/fvt/api_templates/test_guest_grow_root_volume_req.tpl
+   :language: javascript
+
+* Response code:
+
+  HTTP status code 200 on success.
+
+* Response contents:
+
 Get Guest power state
 ---------------------
 

--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -281,6 +281,13 @@ def req_guest_live_resize_mem(start_index, *args, **kwargs):
     return url, body
 
 
+def req_guest_grow_root_volume(start_index, *args, **kwargs):
+    url = '/guests/%s/action'
+    body = {'action': 'grow_root_volume',
+            'os_version': args[start_index]}
+    return url, body
+
+
 def req_guest_capture(start_index, *args, **kwargs):
     url = '/guests/%s/action'
     body = {'action': 'capture',
@@ -681,6 +688,11 @@ DATABASE = {
         'args_required': 2,
         'params_path': 1,
         'request': req_guest_resize_mem},
+    'guest_grow_root_volume': {
+        'method': 'POST',
+        'args_required': 2,
+        'params_path': 1,
+        'request': req_guest_grow_root_volume},
     'guest_capture': {
         'method': 'POST',
         'args_required': 2,

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1264,6 +1264,20 @@ class SDKAPI(object):
         with zvmutils.log_and_reraise_sdkbase_error(action):
             self._vmops.guest_config_minidisks(userid, disk_info)
 
+    @check_guest_exist()
+    def guest_grow_root_volume(self, userid, os_version):
+        """ Punch script to guest to grow root partition and extend
+            root file system.
+            Note:
+            1. Only multipath SCSI disk is supported.
+            2. Only one partition is supported.
+            3. xfs file system is not supported.
+
+        :param str userid: the user id of the vm
+        :param str os_version: operating system version of the guest
+        """
+        return self._vmops.guest_grow_root_volume(userid, os_version)
+
     def vswitch_set(self, vswitch_name, **kwargs):
         """Change the configuration of an existing virtual switch
 

--- a/zvmsdk/dist.py
+++ b/zvmsdk/dist.py
@@ -595,6 +595,11 @@ class LinuxDist(object):
         template = env.get_template(template_name)
         return template
 
+    def get_extend_partition_cmds(self):
+        template = self.get_template("vmactions", "grow_root_volume.j2")
+        content = template.render()
+        return content
+
 
 class rhel(LinuxDist):
     def _get_network_file_path(self):

--- a/zvmsdk/sdkwsgi/handlers/guest.py
+++ b/zvmsdk/sdkwsgi/handlers/guest.py
@@ -354,6 +354,12 @@ class VMAction(object):
 
         return info
 
+    @validation.schema(guest.grow_root_volume)
+    def grow_root_volume(self, userid, body=None):
+        info = self.client.send_request('guest_grow_root_volume', userid,
+                                        body['os_version'])
+        return info
+
     @validation.schema(guest.deploy)
     def deploy(self, userid, body):
         image_name = body['image']

--- a/zvmsdk/sdkwsgi/schemas/guest.py
+++ b/zvmsdk/sdkwsgi/schemas/guest.py
@@ -133,6 +133,16 @@ config_minidisks = {
 }
 
 
+grow_root_volume = {
+    'type': 'object',
+    'properties': {
+        'os_version': parameter_types.os_version,
+    },
+    'required': ['os_version'],
+    'additionalProperties': False,
+}
+
+
 create_disks = {
     'type': 'object',
     'properties': {

--- a/zvmsdk/tests/fvt/api_templates/test_guest_grow_root_volume_req.tpl
+++ b/zvmsdk/tests/fvt/api_templates/test_guest_grow_root_volume_req.tpl
@@ -1,0 +1,4 @@
+{
+  "action": "grow_root_volume",
+  "os_version": "RHEL7.8"
+}

--- a/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
+++ b/zvmsdk/tests/unit/sdkclientcases/test_restclient.py
@@ -903,3 +903,22 @@ class RESTClientTestCase(unittest.TestCase):
         request.assert_called_with(method, full_uri,
                                    data=body, headers=header,
                                    verify=False)
+
+    @mock.patch.object(requests, 'request')
+    @mock.patch('zvmconnector.restclient.RESTClient._get_token')
+    def test_guest_grow_root_volume(self, get_token, request):
+        method = 'POST'
+        url = '/guests/%s/action' % self.fake_userid
+        body = {'action': 'grow_root_volume',
+                'os_version': 'RHEL7.8'}
+        body = json.dumps(body)
+        header = self.headers
+        full_uri = self.base_url + url
+        request.return_value = self.response
+        get_token.return_value = self._tmp_token()
+
+        self.client.call("guest_grow_root_volume", self.fake_userid,
+                         'RHEL7.8')
+        request.assert_called_with(method, full_uri,
+                                   data=body, headers=header,
+                                   verify=False)

--- a/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
+++ b/zvmsdk/tests/unit/sdkwsgi/handlers/test_guest.py
@@ -350,6 +350,18 @@ class GuestActionsTest(SDKWSGITest):
 
     @mock.patch.object(util, 'wsgi_path_item')
     @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
+    def test_guest_grow_root_volume(self, mock_action, mock_userid):
+        self.req.body = """{"action": "grow_root_volume",
+                            "os_version": "RHEL7.8"}"""
+        mock_action.return_value = ''
+        mock_userid.return_value = FAKE_USERID
+
+        guest.guest_action(self.req)
+        mock_action.assert_called_once_with('guest_grow_root_volume',
+                                            FAKE_USERID, "RHEL7.8")
+
+    @mock.patch.object(util, 'wsgi_path_item')
+    @mock.patch('zvmconnector.connector.ZVMConnector.send_request')
     def test_guest_deploy(self, mock_action,
                           mock_userid):
         self.req.body = """{"action": "deploy",

--- a/zvmsdk/tests/unit/test_api.py
+++ b/zvmsdk/tests/unit/test_api.py
@@ -268,6 +268,12 @@ class SDKAPITestCase(base.SDKTestCase):
         self.api.guest_resize_mem(self.userid, size)
         resize_memory.assert_called_once_with(self.userid, size)
 
+    @mock.patch("zvmsdk.vmops.VMOps.guest_grow_root_volume")
+    def test_guest_grow_root_volume(self, grow_root_volume):
+        os_version = "RHEL7.8"
+        self.api.guest_grow_root_volume(self.userid, os_version)
+        grow_root_volume.assert_called_once_with(self.userid, os_version)
+
     @mock.patch("zvmsdk.networkops.NetworkOPS.grant_user_to_vswitch")
     def test_vswitch_grant_user(self, guv):
         self.api.vswitch_grant_user("testvsw", self.userid)

--- a/zvmsdk/vmactions/templates/grow_root_volume.j2
+++ b/zvmsdk/vmactions/templates/grow_root_volume.j2
@@ -1,0 +1,154 @@
+#!/bin/bash
+###############################################################################
+# Copyright 2020 IBM Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#                            #
+###############################################################################
+# COMPONENT: gpartvol.sh                                                      #
+#                                                                             #
+# Grow the root partition on multipath disk of the deployed guest.            #
+###############################################################################
+
+# check multipathd service running
+multipathd_status=`systemctl status multipathd | grep "active (running)"`
+if [[ $? -ne 0 ]]; then
+    echo "multipathd service is inactive, abort extending the root partition."
+    exit 1
+fi
+
+# check parted tool is installed
+output=`which parted`
+if [[ $? -ne 0 ]]; then
+    echo "parted is not installed, please install this tool in the base image."
+    echo "abort extending the root partition."
+    exit 1
+fi
+
+# get root partition
+root_fs=`df --output='source' / | tail -n 1 | grep '/dev/mapper/'`
+rc=$?
+# sample root_fs
+# on RHEL7: 
+# /dev/mapper/36005076802880052a0000000000009fb1
+# sometimes it will be /dev/mapper/36005076802880052a0000000000009fbp1 (with an additional 'p' before '1')
+# on RHEL8: /dev/mapper/mpathb1
+if [[ $rc -ne 0 || "$root_fs" == "" ]]; then
+    echo "Unable to find a multipath root partition with /dev/mapper/."
+    exit 1
+fi
+
+# remove the previous /dev/mapper/ section, mpath value is 36005076802880052a0000000000009fb1 or mpathb1
+mpath=${root_fs#/dev/mapper/}
+# remove the last number 1
+mpath=${mpath%1*}
+
+if [[ -f /etc/multipath/bindings ]]; then
+    mpathx=`grep "$mpath" /etc/multipath/bindings | awk '{print $1}'`
+    if [[ $? -ne 0 || "$mpathx" == "" ]]; then
+        echo "Failed to find multipath bindings of $mpath."
+        if [[ ${mpath:(-1)} == 'p' ]]; then
+            # handling the /dev/mapper/36005076802880052a0000000000009fbp1 case
+            mpath=${mpath%p*}
+            echo "Continue to check bindings of $mpath..."
+            mpathx=`grep "$mpath" /etc/multipath/bindings | awk '{print $1}'`
+            if [[ $? -ne 0 || "$mpathx" == "" ]]; then
+                echo "Abort extending the root partition."
+	        	exit 1
+	        fi
+        else
+	        echo "Abort extending the root partition."
+	        exit 1
+	    fi
+    fi
+else
+    # cases when friendly names is not enabled. (RHEL7.8 and RHEL8.1 enabled by default, but not default in RHEL7.7.)
+    # If no friendly names, the naming would be /dev/mapper/xxxx where xxxx is the scsi wwid.
+    echo "File /etc/multipath/bindings does not exist, assuming 'user_friendly_names' is not enabled in /etc/multipath.conf."
+    mpathx=$mpath
+fi
+echo "root partition path found: $mpathx."
+
+# Ensure the $mpathx path exists
+if [[ ! -r "/dev/mapper/$mpathx" ]]; then
+    echo "/dev/mapper/$mpathx does not exists, abort extending the root partition."
+    exit 1
+fi
+
+# check partition number
+partition_count=`lsblk /dev/mapper/$mpathx -l | awk 'NR>1 && $6=="part" {print $0}' | wc -l`
+if [[ $? -ne 0 ]]; then
+    echo "Failed to get partition number with lsblk /dev/mapper/$mpathx cmd."
+    echo "Aborting extending the root partition. "
+    exit 1
+fi
+if [[ $partition_count -ne 1 ]]; then
+    echo "Get $partition_count partitions exist on the /dev/mapper/$mpathx."
+    echo "Only one partition is supported on the root volume, aborting extending the root partition."
+    exit 1
+fi
+
+# Check partition size
+# Sample lsblk: 
+# lsblk /dev/mapper/mpathb -l
+# NAME    MAJ:MIN RM SIZE RO TYPE  MOUNTPOINT
+# mpathb  253:0    0  10G  0 mpath
+# mpathb1 253:1    0  10G  0 part  /
+part_size=`lsblk /dev/mapper/$mpathx -l | awk 'NR>1 && $6=="part" {print $4}'`
+vol_size=`lsblk /dev/mapper/$mpathx -l | awk 'NR>1 && $6=="mpath" {print $4}'`
+echo "Partition size: $part_size, volume size: $vol_size."
+if [[ "$part_size" == "$vol_size" ]]; then
+    echo "Partition size equals to the root volume size, no need to extend partition."
+    exit 0
+fi
+
+# sample dm_name: dm-0
+dm_name=`readlink /dev/mapper/$mpathx | awk -F'/' '{print $2}'`
+echo "Find root partition on dm path: $dm_name"
+# get the devices name sdx to be used by growpart
+sds=`ls /sys/devices/virtual/block/$dm_name/slaves`
+# grow partition
+success=0
+for sdN in $sds
+do
+    out=`parted -s /dev/$sdN resizepart 1 100%`
+    if [[ $? -eq 0 ]]; then
+        success=1
+    else
+        echo "/dev/$sdN resize failed with parted command, error: $out."
+        continue
+    fi
+done
+if [[ $success == 0 ]]; then
+    echo "All slaves of $mpathx failed to be resized, abort extending the root partition."
+    exit 1
+fi
+# continue to resize multipath partition
+out=`parted -s /dev/mapper/$mpathx resizepart 1 100%`
+rc=$?
+# On RHEL8 the parted for mpathx would return 1 even if the partition is resized successfully.
+# so cann't decide whether this is success or not based on the rc and just print all info out.
+echo "root partition extended. RC: $rc, Output: $out."
+
+echo "Continue to resize root file system."
+# TODO: xfs is not supported now, should use xfs_growfs cmd to extend for xfs.
+out=`resize2fs /dev/mapper/${mpathx}1`
+rc=$?
+if [[ $rc -ne 0 ]]; then
+    echo "Failed to resize root file system, RC: $rc, Output: $out."
+    exit 1
+else
+    echo "Root file system resized successfully."
+    exit 0
+fi
+   


### PR DESCRIPTION
we cann't rely on cloud-init to extend root partition when the partition is on a multipath disk. So add a new API in this PR to do the extention of guest root volume, by punching a script to the target guest.