### PR TITLE
[1.5.n] Reserve FCP devices when deploying VMs

### DIFF
--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -478,6 +478,20 @@ class TestFCPManager(base.SDKTestCase):
             self.db_op.delete('c83c')
             self.db_op.delete('c83d')
 
+    def test_get_available_fcp_reserved(self):
+        self.db_op.new('c83c', 0)
+        self.db_op.new('c83d', 1)
+
+        try:
+            self.fcpops.get_available_fcp('user1')
+            res1 = self.db_op.is_reserved('c83c')
+            res2 = self.db_op.is_reserved('c83d')
+            self.assertTrue(res1)
+            self.assertTrue(res2)
+        finally:
+            self.db_op.delete('c83c')
+            self.db_op.delete('c83d')
+
 
 class TestFCPVolumeManager(base.SDKTestCase):
 
@@ -827,6 +841,10 @@ class TestFCPVolumeManager(base.SDKTestCase):
                                                          wwpns,
                                                          '2222', True, 'rhel7',
                                                          '/dev/sdz', 0)])
+            res1 = self.db_op.is_reserved('183c')
+            res2 = self.db_op.is_reserved('283c')
+            self.assertFalse(res1)
+            self.assertFalse(res2)
         finally:
             self.db_op.delete('183c')
             self.db_op.delete('283c')

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -513,6 +513,8 @@ class FCPManager(object):
             free_unreserved = self.db.get_fcp_pair()
             for item in free_unreserved:
                 available_list.append(item)
+                # Reserve fcp device
+                self.db.reserve(item)
             if free_unreserved is None:
                 LOG.info("no more fcp to be allocated")
                 return None
@@ -655,6 +657,8 @@ class FCPVolumeManager(object):
                 multipath, os_version, mount_point, is_root_volume):
         """Detach a volume from a guest"""
         LOG.info('Start to detach device from %s' % assigner_id)
+        # Unreserved fcp device
+        self.fcp_mgr.unreserve_fcp(fcp)
         connections = self.fcp_mgr.decrease_fcp_usage(fcp, assigner_id)
         if is_root_volume:
             LOG.info('Detaching device from %s is done.' % assigner_id)


### PR DESCRIPTION
Reserve and unreserve FCP devices when deplying and deleting VMs.

Signed-off-by: changzhi <changzhi1990@gmail.com>