### PR TITLE
[1.5.n] make the fcp exception more accurate

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -103,6 +103,10 @@ def get_fcp_conn():
     _DBLOCK_FCP.acquire()
     try:
         yield _FCP_CONN
+    except exception.SDKBaseException as err:
+        msg = "Got SDK exception in FCP DB operation: %s" % six.text_type(err)
+        LOG.error(msg)
+        raise
     except Exception as err:
         msg = "Execute SQL statements error: %s" % six.text_type(err)
         LOG.error(msg)


### PR DESCRIPTION
when the fcp connections is already 0 and then detach_volume is called again,
exception.SDKObjectNotExistError error should be raised and returned to the zcc caller
instead of SDKGuestOperationError.
so that the caller layer can check the error and ignore as needed.

Signed-off-by: dyyang <dyyang@cn.ibm.com>