### PR TITLE
Don't dedicate fcp device if it already dedicate

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -393,13 +393,27 @@ function refreshFCPBootmap {
   # Try to find which physical wwpns are being used.
   for fcp in "${fcps[@]}"
   do
-    # Try to connect FCP device and online it.
-    /opt/zthin/bin/smcli Image_Device_Dedicate -T $zthinUserID -v $fcp -r $fcp
-    if [[ $? -ne 0 ]]; then
-      printError "Dedicate fails, maybe other machines use this FCP: ${fcp}"
-      exit 3
-    fi
+    # Ignore fcp device firstly
     /sbin/cio_ignore -r $fcp > /dev/null
+
+    # Convert the fcp device to upper case
+    fcp_device=($(echo "$fcp"| tr 'a-z' 'A-Z'))
+
+    # Execute the vmcp command, don't execute dedicate command
+    # if the fcp device is already dedicate to the compute node,
+    res=`vmcp q fcp | grep FCP| grep "$fcp_device"`
+
+    # The fcp device doesn't dedicate to the compute node so
+    # dedicate it to the compute node.
+    if [[ -z $res ]]; then
+      # Try to connect FCP device and online it.
+      /opt/zthin/bin/smcli Image_Device_Dedicate -T $zthinUserID -v $fcp -r $fcp
+      if [[ $? -ne 0 ]]; then
+        printError "Dedicate fails, maybe other machines use this FCP: ${fcp}"
+        exit 3
+      fi
+    fi
+
     chccwdevDevice $fcp "online"
     if [[ $? -ne 0 ]]; then
       # Online failed

--- a/zthin-parts/zthin/lib/zthinshellutils
+++ b/zthin-parts/zthin/lib/zthinshellutils
@@ -443,9 +443,13 @@ function chccwdevDevice {
   fi
   englishOpt=$turnOn
 
-  # Enable or disable the device
-  chccwdev $opt $device &> /dev/null
+  output=$(chccwdev $opt $device 2>&1)
   local rc=$?
+  res=$(echo $output|grep "not found")
+  if [[ ($rc -ne 0) && $res ]]; then
+    return 1
+  fi
+
   if [[ $rc -ne 0 ]]; then
     inform "Attempt to set device $englishOpt failed and return code is $rc. Retrying..." 1>&2
     # retry, while waiting various durations
@@ -456,6 +460,7 @@ function chccwdevDevice {
       if [[ $rc -eq 0 ]]; then
         break # successful - leave loop
       fi
+
     done
 
     # Set subroutine return code if chccwdev attempts failed

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -743,7 +743,7 @@ class SMTClient(object):
             LOG.error(err_msg + err_output)
             raise exception.SDKVolumeOperationError(rs=5,
                                                     errcode=rc,
-                                                    errmsg=output)
+                                                    errmsg=err_output)
         output_lines = output.split('\n')
         res = []
         for line in output_lines:


### PR DESCRIPTION
If a FCP device is aleady dedicate to the compute node,
do not execute the dedicate command.

By this way, we can implement:
1. Disconnect a FCP device when the FCP device is already dedicate to
the compute node.
2. Break the loop if the FCP device can't be found.

Signed-off-by: changzhi <changzhi1990@gmail.com>