### PR TITLE
add retry to the volume extend tool

### DIFF
--- a/zvmsdk/vmactions/templates/grow_root_volume.j2
+++ b/zvmsdk/vmactions/templates/grow_root_volume.j2
@@ -27,6 +27,10 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+# In some scenario, the df output the wrong multipath name
+echo "Reloading multipath mapping."
+multipath -r &> /dev/null
+
 # check parted tool is installed
 output=`which parted`
 if [[ $? -ne 0 ]]; then
@@ -142,13 +146,35 @@ echo "root partition extended. RC: $rc, Output: $out."
 
 echo "Continue to resize root file system."
 # TODO: xfs is not supported now, should use xfs_growfs cmd to extend for xfs.
-out=`resize2fs /dev/mapper/${mpathx}1`
+out=`resize2fs /dev/mapper/${mpathx}1 2>&1`
 rc=$?
 if [[ $rc -ne 0 ]]; then
     echo "Failed to resize root file system, RC: $rc, Output: $out."
     exit 1
 else
+    # In some scenario, the resize2fs does not recognize the new partition size
+    # Sample: "The filesystem is already 2621184 (4k) blocks long.  Nothing to do!"
+    # So add some retry here.
+    if [[ $out =~ "Nothing to do!" ]]; then
+        echo "Doing some retry for resize2fs."
+        sleepTimes=".001 .01 .1 .5 1 2 3 5 8 15 22 34 60"
+        for seconds in $sleepTimes; do
+            sleep $seconds
+            out=`resize2fs /dev/mapper/${mpathx}1 2>&1`
+            rc=$?
+            if [[ $rc -ne 0 ]]; then
+                echo "Failed to resize root file system, RC: $rc, Output: $out."
+                exit 1
+            fi
+            if [[ ! ($out =~ "Nothing to do!") ]]; then
+                break # successful - leave loop
+            fi
+	    done
+	    if [[ $out =~ "Nothing to do!" ]]; then
+	        echo "Failed to resize root file system!"
+	        exit 1
+	    fi
+	fi
     echo "Root file system resized successfully."
     exit 0
 fi
-   


### PR DESCRIPTION
Two changes in this patch:

1. In some cases, the resize2fs cann't recognize the new extended partition space.
This patch add some sleep and retry to this operation.
2. In some scenario, the df output the wrong multipath name, so reload multipath mappings before we use df to find the root multipath name.