### PR TITLE
[Master]add assigner to the new allocated FCP in database

### DIFF
--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -513,6 +513,11 @@ class FCPManager(object):
             free_unreserved = self.db.get_fcp_pair()
             for item in free_unreserved:
                 available_list.append(item)
+                # record the assigner id in the fcp so that
+                # when the vm provision with both root and data volumes
+                # the root and data volume would get the same FCP devices
+                # with the get_volume_connector call.
+                self.db.assign(item, assigner_id)
                 # Reserve fcp device
                 self.db.reserve(item)
             if free_unreserved is None:


### PR DESCRIPTION
when the vm provision with both root and data volumes, the get_volume_connector would
be called for both the root and data volume. We need to add the assigner id in fcp database
so that we would get the same FCP devices with these get_volume_connector call.