### PR TITLE
[Master] Do not touch the connections in fcp database in get_available_fcp

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -350,11 +350,16 @@ class FCPDbOperator(object):
                          "(?, ?, ?, ?, ?, ?)",
                          (fcp, '', 0, 0, path, ''))
 
-    def assign(self, fcp, assigner_id):
+    def assign(self, fcp, assigner_id, update_connections=True):
         with get_fcp_conn() as conn:
-            conn.execute("UPDATE fcp SET assigner_id=?, connections=? "
-                         "WHERE fcp_id=?",
-                         (assigner_id, 1, fcp))
+            if update_connections:
+                conn.execute("UPDATE fcp SET assigner_id=?, connections=? "
+                             "WHERE fcp_id=?",
+                             (assigner_id, 1, fcp))
+            else:
+                conn.execute("UPDATE fcp SET assigner_id=? "
+                             "WHERE fcp_id=?",
+                             (assigner_id, fcp))
 
     def delete(self, fcp):
         with get_fcp_conn() as conn:

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -517,7 +517,7 @@ class FCPManager(object):
                 # when the vm provision with both root and data volumes
                 # the root and data volume would get the same FCP devices
                 # with the get_volume_connector call.
-                self.db.assign(item, assigner_id)
+                self.db.assign(item, assigner_id, update_connections=False)
                 # Reserve fcp device
                 self.db.reserve(item)
             if free_unreserved is None:


### PR DESCRIPTION
We should just set the assigner id and not change the connections
in get_available_fcp. The connections are maintained in attach and detach
steps.

Signed-off-by: dyyang <dyyang@cn.ibm.com>