### PR TITLE
[1.5.n] Ignore the fdasd error when create the partition table

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -1201,9 +1201,14 @@ EOF
     # format the ECKD DASD using fdasd program
     inform "Create partitions..."
     fdasd --silent --config /tmp/${userID}/fdasd_conf "${DEST_DEV}"
-    if [[ $? -ne 0 ]]; then
-        printError "failed to set partition for RHCOS DASD device"
-        exit 3
+    RETCODE=$?
+    if [[ $RETCODE -ne 0 ]]; then
+        if [[ $RETCODE -eq 255 ]]; then
+            inform "Ignore the error while rereading partition table."
+        else
+            printError "failed to set partition for RHCOS DASD device"
+            exit 3
+        fi
     fi
 
     # copy the content of each partition


### PR DESCRIPTION
occasionlly there will be IOCTL error when using fdasd to set the
partiton table, this error happened when rereading the partion table,
it looks like a timing issue problem. And it will not cause the image
copy failure. The VM still can be boot up.

Signed-off-by: ylpan <ylpan@cn.ibm.com>