### PR TITLE
[1.5.n]rollback all dedicated fcp when got exception (#249)

### DIFF
--- a/zvmsdk/database.py
+++ b/zvmsdk/database.py
@@ -433,7 +433,15 @@ class FCPDbOperator(object):
         with get_fcp_conn() as conn:
             result = conn.execute("SELECT connections FROM fcp WHERE "
                                   "fcp_id=?", (fcp,))
-            connections = result.fetchall()
+            fcp_info = result.fetchall()
+            if not fcp_info:
+                msg = 'FCP with id: %s does not exist in DB.' % fcp
+                LOG.error(msg)
+                obj_desc = "FCP with id: %s" % fcp
+                raise exception.SDKObjectNotExistError(obj_desc=obj_desc,
+                                                       modID=self._module_id)
+            connections = fcp_info[0][0]
+
         return connections
 
     def get_from_assigner(self, assigner_id):
@@ -460,6 +468,14 @@ class FCPDbOperator(object):
             fcp_list = result.fetchall()
 
         return fcp_list
+
+    def get_path_count(self):
+        with get_fcp_conn() as conn:
+            # Get distinct path list in DB
+            result = conn.execute("SELECT DISTINCT path FROM fcp")
+            path_list = result.fetchall()
+
+        return len(path_list)
 
     def get_fcp_pair(self):
         fcp_list = []

--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -344,11 +344,11 @@ class TestFCPManager(base.SDKTestCase):
 
         # find FCP for user and FCP not exist, should allocate them
         try:
-            flag1 = self.fcpops.add_fcp_for_assigner(2, 'a83c', 'dummy1')
-            flag2 = self.fcpops.add_fcp_for_assigner(2, 'a83d', 'dummy2')
+            flag1 = self.fcpops.add_fcp_for_assigner('a83c', 'dummy1')
+            flag2 = self.fcpops.add_fcp_for_assigner('a83d', 'dummy2')
 
-            flag1 = self.fcpops.add_fcp_for_assigner(2, 'a83e', 'dummy1')
-            flag2 = self.fcpops.add_fcp_for_assigner(2, 'a83f', 'dummy2')
+            flag1 = self.fcpops.add_fcp_for_assigner('a83e', 'dummy1')
+            flag2 = self.fcpops.add_fcp_for_assigner('a83f', 'dummy2')
 
             self.assertEqual(True, flag1)
             self.assertEqual(True, flag2)
@@ -410,7 +410,7 @@ class TestFCPManager(base.SDKTestCase):
             self.fcpops.increase_fcp_usage('c83c', 'user1')
 
             fcp_list = self.db_op.get_from_fcp('c83c')
-            expected = [(u'c83c', u'', 1, 1, 0, u'')]
+            expected = [(u'c83c', u'user1', 1, 1, 0, u'')]
             self.assertEqual(expected, fcp_list)
 
             # After usage, we need find c83d now
@@ -422,19 +422,10 @@ class TestFCPManager(base.SDKTestCase):
 
             self.fcpops.increase_fcp_usage('c83c', 'user1')
             fcp_list = self.db_op.get_from_fcp('c83c')
-            expected = [(u'c83c', u'', 2, 1, 0, u'')]
+            expected = [(u'c83c', u'user1', 2, 1, 0, u'')]
             self.assertEqual(expected, fcp_list)
 
             self.fcpops.decrease_fcp_usage('c83c', 'user1')
-            fcp_list = self.db_op.get_from_fcp('c83c')
-            expected = [(u'c83c', u'', 1, 1, 0, u'')]
-            self.assertEqual(expected, fcp_list)
-
-            # add_fcp_for_assigner is designed for multipath
-            # so if multipath is enabled(path_count >= 2),
-            # add_fcp_for_assinger used on an instance exsited in DB,
-            # will not increase the connections
-            self.fcpops.add_fcp_for_assigner(2, 'c83c', 'user1')
             fcp_list = self.db_op.get_from_fcp('c83c')
             expected = [(u'c83c', u'user1', 1, 1, 0, u'')]
             self.assertEqual(expected, fcp_list)
@@ -706,12 +697,11 @@ class TestFCPVolumeManager(base.SDKTestCase):
 
     @mock.patch("zvmsdk.volumeop.FCPManager._get_all_fcp_info")
     @mock.patch("zvmsdk.utils.check_userid_exist")
-    @mock.patch("zvmsdk.volumeop.FCPVolumeManager._undedicate_fcp")
+    @mock.patch("zvmsdk.volumeop.FCPVolumeManager._rollback_dedicated_fcp")
     @mock.patch("zvmsdk.volumeop.FCPVolumeManager._dedicate_fcp")
-    @mock.patch("zvmsdk.volumeop.FCPManager.decrease_fcp_usage")
-    @mock.patch("zvmsdk.volumeop.FCPManager.increase_fcp_usage")
-    def test_attach_rollback(self, mock_increase, mock_decrease,
-                             mock_dedicate, mock_undedicate,
+    @mock.patch("zvmsdk.volumeop.FCPManager.add_fcp_for_assigner")
+    def test_attach_rollback(self, mock_fcp_assigner,
+                             mock_dedicate, mock_rollback,
                              mock_check, mock_fcp_info):
         connection_info = {'platform': 'x86_64',
                            'ip': '1.2.3.4',
@@ -731,18 +721,18 @@ class TestFCPVolumeManager(base.SDKTestCase):
                     '20076D8500005181']
         mock_fcp_info.return_value = fcp_list
         mock_check.return_value = True
-        mock_increase.return_value = True
+        mock_fcp_assigner.return_value = True
         results = {'rs': 0, 'errno': 0, 'strError': '',
                    'overallRC': 1, 'logEntries': [], 'rc': 0,
                    'response': ['fake response']}
         mock_dedicate.side_effect = exception.SDKSMTRequestFailed(
             results, 'fake error')
-        # return value of decreate must bigger than 1
-        mock_decrease.return_value = 0
         self.assertRaises(exception.SDKBaseException,
                           self.volumeops.attach,
                           connection_info)
-        mock_undedicate.assert_called_once_with('e83c', 'USER1')
+        calls = [mock.call(['e83c'], 'USER1'),
+                 mock.call([], 'USER1')]
+        mock_rollback.assert_has_calls(calls)
 
     @mock.patch("zvmsdk.volumeop.FCPManager._get_all_fcp_info")
     @mock.patch("zvmsdk.utils.check_userid_exist")

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -464,21 +464,14 @@ class FCPManager(object):
 
         return new
 
-    def add_fcp_for_assigner(self, path_count, fcp, assigner_id=None):
+    def add_fcp_for_assigner(self, fcp, assigner_id=None):
         """Incrase fcp usage of given fcp
-        path_count: how many paths we will use in multipath
         Returns True if it's a new fcp, otherwise return False
         """
         # get the sum of connections belong to assinger_id
-        connections = self.db.get_connections_from_assigner(assigner_id)
+        connections = self.db.get_connections_from_fcp(fcp)
         new = False
-        # TODO: we assume that the connections of every FCP at most is 1,
-        # TODO: so multiattach will not be supported.
-        # Now because support multipath, so if sum connections of one assigner
-        # < path_count, we think not all the FCP devices attached to the
-        # instance. So a new FCP still should be attached to the instance
-        # and the new flag still need set to True.
-        if connections < path_count:
+        if connections == 0:
             # ATTENTION: logically, only new fcp was added
             self.db.assign(fcp, assigner_id)
             new = True
@@ -524,6 +517,12 @@ class FCPManager(object):
             LOG.debug("allocated %s fcp for %s assigner" %
                       (available_list, assigner_id))
         else:
+            path_count = self.db.get_path_count()
+            if len(fcp_list) < path_count:
+                # TODO: handle the case when len(fcp_list) < multipath_count
+                LOG.warning("FCPs assigned to %s includes %s, "
+                            "it is less than the path count: %s." %
+                            (assigner_id, fcp_list, path_count))
             # we got it from db, let's reuse it
             for old_fcp in fcp_list:
                 available_list.append(old_fcp[0])
@@ -559,6 +558,15 @@ class FCPVolumeManager(object):
                                       target_lun, multipath, os_version,
                                       mount_point, new)
 
+    def _rollback_dedicated_fcp(self, fcp_list, assigner_id):
+        # fcp param should be a list
+        for fcp in fcp_list:
+            with zvmutils.ignore_errors():
+                LOG.info("Rolling back dedicated FCP: %s" % fcp)
+                connections = self.fcp_mgr.decrease_fcp_usage(fcp, assigner_id)
+                if connections == 0:
+                    self._undedicate_fcp(fcp, assigner_id)
+
     def _attach(self, fcp, assigner_id, target_wwpns, target_lun,
                 multipath, os_version, mount_point, path_count,
                 is_root_volume):
@@ -572,10 +580,10 @@ class FCPVolumeManager(object):
         # TODO: init_fcp should be called in contructor function
         # but no assinger_id in contructor
         self.fcp_mgr.init_fcp(assigner_id)
-        new = self.fcp_mgr.add_fcp_for_assigner(path_count, fcp, assigner_id)
+        new = self.fcp_mgr.add_fcp_for_assigner(fcp, assigner_id)
         if is_root_volume:
             LOG.info('Attaching device to %s is done.' % assigner_id)
-            return
+            return new
         try:
             if new:
                 self._dedicate_fcp(fcp, assigner_id)
@@ -583,17 +591,14 @@ class FCPVolumeManager(object):
             self._add_disk(fcp, assigner_id, target_wwpns, target_lun,
                            multipath, os_version, mount_point, new)
         except exception.SDKBaseException as err:
-            errmsg = 'rollback attach because error:' + err.format_message()
+            errmsg = 'Attach failed with error:' + err.format_message()
             LOG.error(errmsg)
-            connections = self.fcp_mgr.decrease_fcp_usage(fcp, assigner_id)
-            # if connections less than 1, undedicate the device
-            if not connections:
-                with zvmutils.ignore_errors():
-                    self._undedicate_fcp(fcp, assigner_id)
+            self._rollback_dedicated_fcp([fcp], assigner_id)
             raise exception.SDKBaseException(msg=errmsg)
         # TODO: other exceptions?
 
         LOG.info('Attaching device to %s is done.' % assigner_id)
+        return new
 
     def volume_refresh_bootmap(self, fcpchannels, wwpns, lun, skipzipl=False):
         """ Refresh a volume's bootmap info.
@@ -641,10 +646,18 @@ class FCPVolumeManager(object):
         else:
             # TODO: the length of fcp is the count of paths in multipath
             path_count = len(fcp)
+            dedicated_fcp = []
             for i in range(path_count):
-                self._attach(fcp[i].lower(), assigner_id, target_wwpns,
-                             target_lun, multipath, os_version, mount_point,
-                             path_count, is_root_volume)
+                try:
+                    new = self._attach(fcp[i].lower(), assigner_id,
+                                       target_wwpns, target_lun, multipath,
+                                       os_version, mount_point, path_count,
+                                       is_root_volume)
+                    if new and is_root_volume is False:
+                        dedicated_fcp.append(fcp[i])
+                except exception.SDKBaseException:
+                    self._rollback_dedicated_fcp(dedicated_fcp, assigner_id)
+                    raise
 
     def _undedicate_fcp(self, fcp, assigner_id):
         self._smtclient.undedicate_device(assigner_id, fcp)
@@ -673,7 +686,7 @@ class FCPVolumeManager(object):
                 self._undedicate_fcp(fcp, assigner_id)
         except (exception.SDKBaseException,
                 exception.SDKSMTRequestFailed) as err:
-            errmsg = 'rollback detach because error:' + err.format_message()
+            errmsg = 'detach failed with error:' + err.format_message()
             LOG.error(errmsg)
             self.fcp_mgr.increase_fcp_usage(fcp, assigner_id)
             with zvmutils.ignore_errors():


### PR DESCRIPTION
With attach, there would be multiple fcp to be dedicated. Previously if
one fcp dedicate failed, only the current fcp will be rollback.
This PR will also rollback the previously dedicated fcps.

Signed-off-by: dyyang <dyyang@cn.ibm.com>

Co-authored-by: Huang Rui <bjhuangr@users.noreply.github.com>