### PR TITLE
[1.5.n]Add reserve flag to get_volume_connector

### DIFF
--- a/zvmconnector/restclient.py
+++ b/zvmconnector/restclient.py
@@ -430,7 +430,13 @@ def req_volume_refresh_bootmap(start_index, *args, **kwargs):
 
 def req_get_volume_connector(start_index, *args, **kwargs):
     url = '/volumes/conn/%s'
-    body = None
+    reserve = kwargs.get('reserve', False)
+    body = {'info':
+        {
+            "reserve": reserve
+        }
+    }
+    fill_kwargs_in_body(body['info'], **kwargs)
     return url, body
 
 

--- a/zvmsdk/api.py
+++ b/zvmsdk/api.py
@@ -1423,7 +1423,7 @@ class SDKAPI(object):
         """
         self._networkops.delete_vswitch(vswitch_name, persist)
 
-    def get_volume_connector(self, userid):
+    def get_volume_connector(self, userid, reserve=False):
         """Get connector information of the guest for attaching to volumes.
         This API is for Openstack Cinder driver only now.
 
@@ -1439,8 +1439,9 @@ class SDKAPI(object):
         This information will be used by IBM storwize FC driver in Cinder.
 
         :param str userid: the user id of the guest
+        :param boolean reserve: the flag to reserve FCP device
         """
-        return self._volumeop.get_volume_connector(userid)
+        return self._volumeop.get_volume_connector(userid, reserve)
 
     def volume_attach(self, connection_info):
         """ Attach a volume to a guest. It's prerequisite to active multipath

--- a/zvmsdk/sdkwsgi/handlers/volume.py
+++ b/zvmsdk/sdkwsgi/handlers/volume.py
@@ -56,8 +56,9 @@ class VolumeAction(object):
         return info
 
     @validation.query_schema(volume.get_volume_connector)
-    def get_volume_connector(self, req, userid):
-        conn = self.client.send_request('get_volume_connector', userid)
+    def get_volume_connector(self, req, userid, reserve):
+        conn = self.client.send_request('get_volume_connector',
+                                        userid, reserve)
         return conn
 
     def volume_refresh_bootmap(self, fcpchannel, wwpn, lun, skipzipl):
@@ -131,12 +132,15 @@ def volume_refresh_bootmap(req):
 @util.SdkWsgify
 @tokens.validate
 def get_volume_connector(req):
-    def _get_volume_conn(req, userid):
+    def _get_volume_conn(req, userid, reserve):
         action = get_action()
-        return action.get_volume_connector(req, userid)
+        return action.get_volume_connector(req, userid, reserve)
 
     userid = util.wsgi_path_item(req.environ, 'userid')
-    conn = _get_volume_conn(req, userid)
+    body = util.extract_json(req.body)
+    reserve = body['info']['reserve']
+
+    conn = _get_volume_conn(req, userid, reserve)
     conn_json = json.dumps(conn)
 
     req.response.content_type = 'application/json'

--- a/zvmsdk/sdkwsgi/schemas/volume.py
+++ b/zvmsdk/sdkwsgi/schemas/volume.py
@@ -55,6 +55,16 @@ get_volume_connector = {
     'type': 'object',
     'properties': {
         'userid': parameter_types.userid_list,
+        'info': {
+            'type': 'object',
+            'properties': {
+                'reserve': parameter_types.boolean,
+            },
+            'required': ['info'],
+            'additionalProperties': False,
+        },
+        'additionalProperties': False,
     },
     'additionalProperties': False,
+
 }

--- a/zvmsdk/tests/unit/test_volumeop.py
+++ b/zvmsdk/tests/unit/test_volumeop.py
@@ -469,20 +469,6 @@ class TestFCPManager(base.SDKTestCase):
             self.db_op.delete('c83c')
             self.db_op.delete('c83d')
 
-    def test_get_available_fcp_reserved(self):
-        self.db_op.new('c83c', 0)
-        self.db_op.new('c83d', 1)
-
-        try:
-            self.fcpops.get_available_fcp('user1')
-            res1 = self.db_op.is_reserved('c83c')
-            res2 = self.db_op.is_reserved('c83d')
-            self.assertTrue(res1)
-            self.assertTrue(res2)
-        finally:
-            self.db_op.delete('c83c')
-            self.db_op.delete('c83d')
-
 
 class TestFCPVolumeManager(base.SDKTestCase):
 
@@ -513,7 +499,8 @@ class TestFCPVolumeManager(base.SDKTestCase):
         self.db_op.assign('b83c', 'fakeuser')
 
         try:
-            connections = self.volumeops.get_volume_connector('fakeuser')
+            connections = self.volumeops.get_volume_connector('fakeuser',
+                                                              False)
             expected = {'zvm_fcp': ['b83c'],
                         'wwpns': ['2007123400001234'],
                         'host': 'fakehost'}
@@ -731,7 +718,7 @@ class TestFCPVolumeManager(base.SDKTestCase):
                           self.volumeops.attach,
                           connection_info)
         calls = [mock.call(['e83c'], 'USER1'),
-                 mock.call([], 'USER1')]
+                 mock.call([], 'USER1', all_fcp_list=['e83c'])]
         mock_rollback.assert_has_calls(calls)
 
     @mock.patch("zvmsdk.volumeop.FCPManager._get_all_fcp_info")
@@ -771,11 +758,6 @@ class TestFCPVolumeManager(base.SDKTestCase):
         self.assertRaises(exception.SDKBaseException,
                           self.volumeops.detach,
                           connection_info)
-        mock_increase.assert_called_once_with('f83c', 'USER1')
-        mock_add_disk.assert_called_once_with('f83c', 'USER1',
-                                              ['20076D8500005182'], '2222',
-                                              False, 'rhel7', '/dev/sdz',
-                                              True)
 
     @mock.patch("zvmsdk.volumeop.FCPManager._get_all_fcp_info")
     @mock.patch("zvmsdk.utils.check_userid_exist")


### PR DESCRIPTION
In the function get_volume_connector, if the reserve flag is True,
reserve the FCP device. If the reserve flag is False and the FCP's
connections is 0 then unreserve it.

Signed-off-by: changzhi <changzhi1990@gmail.com>