### PR TITLE
[1.5.n] remove the dirty mounts left in fstab when doing refreshbootmap

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -339,6 +339,14 @@ function refreshZIPL {
     inform "The os version is: $os, this is not a supported linux distro"
   fi
 
+  # Remove dirty data in /etc/fstab left by the previous vm deploy
+  # remove lines containing "/mnt/ephemeral" or " swap swap "
+  # TODO: need to update the implementation method when later the ephemeral
+  # mount point maybe changed to user configurable, to not hardcode to /mnt/ephemeralxxx
+  inform "Updating ${deviceMountPoint}/etc/fstab"
+  sed -i '/\/mnt\/ephemeral/d' ${deviceMountPoint}/etc/fstab
+  sed -i '/ swap swap /d' ${deviceMountPoint}/etc/fstab
+
   # Refresh bootmap
   out=`chroot $deviceMountPoint /sbin/zipl 2>&1`
   rc=$?


### PR DESCRIPTION
when the base vm root volume contains ephemeral or swap mounts in
/etc/fstab, and then when use this volume to clone new vm, the new
vm would failed to start because of these dirty mount entries.
This PR removed these ephemeral or swap mount lines from /etc/fstab
when deploying the new vm.

Signed-off-by: dyyang <dyyang@cn.ibm.com>