### PR TITLE
[1.5.n]Remove stale /etc/multipath/bindings and /etc/multipath/wwids

### DIFF
--- a/zthin-parts/zthin/bin/refresh_bootmap
+++ b/zthin-parts/zthin/bin/refresh_bootmap
@@ -347,6 +347,21 @@ function refreshZIPL {
   sed -i '/\/mnt\/ephemeral/d' ${deviceMountPoint}/etc/fstab
   sed -i '/ swap swap /d' ${deviceMountPoint}/etc/fstab
 
+  # Remove stale /etc/multipath/bindings and /etc/multipath/wwids
+  # These files may contain the old info of the captured base vm,
+  # which disrupts the volume bindings of the new vm deployed from above captured image, resulting
+  #  a. mpath name inconsistent between 'df' and 'multipath'
+  #  b. in some scenairo, boot-volume extend partition fail due to 'a'
+  # By removing them, they can be recreated later with correct volume bindings
+  # when multipathd start at vm boot time.
+  inform "Move stale multipath bindings and wwids if any"
+  if [[ -r "${deviceMountPoint}/etc/multipath/bindings" ]]; then
+    mv ${deviceMountPoint}/etc/multipath/bindings ${deviceMountPoint}/etc/multipath/bindings.bak
+  fi
+  if [[ -r "${deviceMountPoint}/etc/multipath/wwids" ]]; then
+    mv ${deviceMountPoint}/etc/multipath/wwids ${deviceMountPoint}/etc/multipath/wwids.bak
+  fi
+
   # Refresh bootmap
   out=`chroot $deviceMountPoint /sbin/zipl 2>&1`
   rc=$?


### PR DESCRIPTION
Remove stale /etc/multipath/bindings and /etc/multipath/wwids

These files may contain the old info of the captured base vm,
which disrupts the volume bindings of the new vm deployed from above captured image, resulting
 a. mpath name inconsistent between 'df' and 'multipath'
 b. in some scenairo, boot-volume extend partition fail due to 'a'
By removing them, they can be recreated later with correct volume bindings
when multipathd start at vm boot time.

Signed-off-by: Da Long Wang <shdlwang@cn.ibm.com>