### PR TITLE
[master]remove PyYaml in test-requirement

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 mock>=2.0.0 # BSD
 python-subunit>=1.0.0 # Apache-2.0/BSD
-PyYAML>=3.10 # MIT
 sphinx>=1.6.2,!=1.8.0 # BSD


### PR DESCRIPTION
Ran 640 tests in 33.166s

OK (skipped=3)
py27 run-test: commands[1] | python -m unittest discover -v -s /root/python-zvm-sdk/smtLayer/tests/unit
test_getDiskPoolSpace3390 (test_getHost.SMTGetHostTestCase) ... ok
test_getDiskPoolSpace3390Unknown (test_getHost.SMTGetHostTestCase) ... ok
test_getDiskPoolSpace3390UnknownWithFlag (test_getHost.SMTGetHostTestCase) ... ok
test_getDiskPoolSpace9336 (test_getHost.SMTGetHostTestCase) ... ok
test_getDiskPoolSpace9336Unknown (test_getHost.SMTGetHostTestCase) ... ok
test_getDiskPoolSpace9336UnknownWithFlag (test_getHost.SMTGetHostTestCase) ... ok
test_getReservedMemSize (test_makeVM.SMTMakeVMTestCase) ... ok
test_getReservedMemSize_equal_size (test_makeVM.SMTMakeVMTestCase) ... ok
test_getReservedMemSize_gap_G (test_makeVM.SMTMakeVMTestCase) ... ok
test_getReservedMemSize_invalid_suffix (test_makeVM.SMTMakeVMTestCase) ... ok
test_getReservedMemSize_max_less_than_initial (test_makeVM.SMTMakeVMTestCase) ... ok
test_getVM_directory_py3 (test_vmUtils.SMTvmUtilsTestCase) ... ok

----------------------------------------------------------------------
Ran 12 tests in 0.002s

OK
__________________________________________________________________ summary __________________________________________________________________
  py27: commands succeeded
  congratulations :)
[root@UT python-zvm-sdk]#