### PR TITLE
[master]seperate path for ubuntu16 and 20 when permanently online the disk

### DIFF
--- a/data/setupDisk
+++ b/data/setupDisk
@@ -544,8 +544,9 @@ function setupDisk {
       fi
     elif [[ $os == sles* ]]; then
       /sbin/dasd_configure 0.0.$xcat_vaddr 1
-    elif [[ $os == ubuntu* ]]; then
+    elif [[ $os == ubuntu20* ]]; then
       chzdev -e dasd 0.0.$xcat_vaddr
+    elif [[ $os == ubuntu16* ]]; then
       touch /etc/sysconfig/hardware/config-ccw-0.0.$xcat_vaddr
     else
       echo "$funcName (Error) failed to permanently online the disk:$xcat_vaddr on os: $os, please check if $os is in the supported distribution list"


### PR DESCRIPTION
Signed-off-by: haolp <haolp@cn.ibm.com>

```
OK
__________________________________________________________________ summary __________________________________________________________________
  py27: commands succeeded
  congratulations :)
[root@UT python-zvm-sdk]# tox -e pep8
pep8 develop-inst-noop: /root/python-zvm-sdk
pep8 installed: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support,attrs==19.3.0,certifi==2020.6.20,chardet==3.0.4,configparser==4.0.2,contextlib2==0.6.0.post1,enum34==1.1.10,flake8==3.8.3,functools32==3.2.3.post2,idna==2.10,importlib-metadata==1.7.0,importlib-resources==2.0.1,jsonschema==3.2.0,mccabe==0.6.1,netaddr==0.7.20,pathlib2==2.3.5,pycodestyle==2.6.0,pyflakes==2.2.0,PyJWT==1.7.1,pyrsistent==0.16.0,PyYAML==5.3.1,repoze.lru==0.7,requests==2.24.0,Routes==2.4.1,scandir==1.10.0,singledispatch==3.4.0.3,six==1.15.0,typing==3.7.4.1,urllib3==1.25.9,WebOb==1.8.6,zipp==1.2.0,-e git+https://github.com/haolp/python-zvm-sdk.git@e0f028222482e3a2810cc9b00e9176f62166d495#egg=zVMCloudConnector
pep8 run-test-pre: PYTHONHASHSEED='1250912304'
pep8 run-test: commands[0] | flake8
pep8 run-test: commands[1] | flake8 /root/python-zvm-sdk/scripts/sdkserver
__________________________________________________________________ summary __________________________________________________________________
  pep8: commands succeeded
  congratulations :)
[root@UT python-zvm-sdk]#
```