### PR TITLE
[master] Remove vmcp modprobe in zvmguestconfigure

### DIFF
--- a/tools/share/zvmguestconfigure
+++ b/tools/share/zvmguestconfigure
@@ -78,7 +78,7 @@ function pullReader {
   #   Return code indicates success if reader was brought online.
   # @Code:
   local funcName="pullReader"
-  /sbin/modprobe vmcp
+  #/sbin/modprobe vmcp
 
   # Online reader
   rc= onlineDevice "000c"


### PR DESCRIPTION
Remove vmcp modprobe in zvmguestconfigure

Signed-off-by: wgxoyun <wgxoyun@cn.ibm.com>