### PR TITLE
type error reported when sending requests to WSGI in zcc

### DIFF
--- a/zvmsdk/sdkwsgi/requestlog.py
+++ b/zvmsdk/sdkwsgi/requestlog.py
@@ -49,6 +49,10 @@ class RequestLog(object):
             for name, value in headers:
                 if name.lower() == 'content-length':
                     size = value
+            for index, value in enumerate(headers):
+                if value[0] == 'X-Auth-Token':
+                    headers[index] = ('X-Auth-Token', value[1].decode('utf-8'))
+                    break
 
             self._write_log(environ, req_uri, status, size, headers,
                             exc_info)


### PR DESCRIPTION
this is because the data type of X-Auth-Token in headers is bytes
but start_response expect unicode type.
so change the type hardly, still need finding the root cause.

Signed-off-by: SharpRazor <bjcb@cn.ibm.com>