### PR TITLE
Revert "parted the partition from 64th track rather than 2nd track 

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -386,30 +386,46 @@ function resizeECKD {
   local partitionsCount=`blkid | grep ${devNode} | wc -l`
   if [[ $partitionsCount -gt 1 ]]; then
     inform "Multiple partitions are detected on root disk. The last partition will be extended."
-  fi  
-
-  # Resize the partition to take the whole disk.
-  # Note: We will see a message indicating that "device is not fully formatted".
-  #       We will ignore that because we are redoing the parition to take 
-  #       advantage of the increased size.
-  partnum=`parted -m ${devNode} print | tail -n 1 | cut -d':' -f1`
-  # Input redirection needed because fdasd does not have a command line parameter for
-  #    u   re-create VTOC re-using existing partition sizes
-  out=`fdasd ${devNode} <<-END
+    partnum=`parted -m ${devNode} print | tail -n 1 | cut -d':' -f1`
+    # Input redirection needed because fdasd does not have a command line parameter for
+    #    u   re-create VTOC re-using existing partition sizes
+    out=`fdasd ${devNode} <<-END
 	u
 	y
 	w
 	END`
-  rc=$?
-  if (( rc != 0 )); then
-    printError "When recreating the VTOC, 'fdasd' to  ${devNode} returns rc: $rc, out: $out"
-    return 1
-  fi
-  out=`parted ${devNode} resizepart $partnum 100%`
-  rc=$?
-  if (( rc != 0 )); then
-    printError "When resizing the dasd, 'parted' to  ${devNode} returns rc: $rc, out: $out"
-    return 1
+    rc=$?
+    if (( rc != 0 )); then
+      printError "When recreating the VTOC, 'fdasd' to  ${devNode} returns rc: $rc, out: $out"
+      return 1
+    fi
+    out=`parted ${devNode} resize $partnum 100%`
+    rc=$?
+    if (( rc != 0 )); then
+      printError "When resizing the dasd, 'parted' to  ${devNode} returns rc: $rc, out: $out"
+      return 1
+    fi
+  else
+    # Resize the partition to take the whole disk.
+    # Note: We will see a message indicating that "device is not fully formatted".
+    #       We will ignore that because we are redoing the parition to take 
+    #       advantage of the increased size.
+    out=`fdasd -a ${devNode}`
+    rc=$?
+    if (( rc != 0 )); then
+      if (( rc == 255 )); then
+        sleep 0.5
+        out=`blockdev --rereadpt ${devNode}`
+        rc=$?
+        if (( rc != 0 )); then
+          printError "When resizing the dasd, 'blockdev --rereadpt' to  ${devNode} returns rc: $rc, out: $out"
+          return 1
+        fi
+      else
+        printError "When resizing the dasd, 'fsdasd -a' to  ${devNode} returns rc: $rc, out: $out"
+        return 1
+      fi
+    fi
   fi
 
   # Reset the device by disconnecting and then reconnecting


### PR DESCRIPTION


This reverts commit 11f08c92967b4425724991e03d4a297695ada65a.
original PR here:
https://github.com/openmainframeproject/python-zvm-sdk/pull/293
