### PR TITLE
[master] Add attach/detach template into zvmsdk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["zvmsdk.tests.fvt*"]),
     package_data={
         'zvmsdk': [
-            'vmactions/templates/grow_root_volume.j2'
+            'vmactions/templates/grow_root_volume.j2',
+            'volumeops/templates/rhel7_attach_volume.j2',
+            'volumeops/templates/rhel7_detach_volume.j2'
         ]
     },
     classifiers=[


### PR DESCRIPTION
Fix the issue of volumeops/templates missing from python-zvm-sdk package.
Add these files as package data.

Signed-off-by: changzhi <changzhi1990@gmail.com>