### PR TITLE
[master] Ignore the fdasd error for rereading partition table

### DIFF
--- a/zthin-parts/zthin/bin/unpackdiskimage
+++ b/zthin-parts/zthin/bin/unpackdiskimage
@@ -1186,7 +1186,22 @@ EOF
     fdasd --silent --config /tmp/${userID}/fdasd_conf "${DEST_DEV}"
     RETCODE=$?
     if [[ $RETCODE -ne 0 ]]; then
-        if [[ $RETCODE -eq 255 ]]; then
+        local os=""
+        local osRelease="/etc/os-release"
+        if [[ -e $osRelease ]]; then
+            os=`cat $osRelease | grep "^ID=" | sed \
+              -e 's/ID=//' \
+              -e 's/"//g'`
+            version=`cat $osRelease | grep "^VERSION_ID=" | sed \
+              -e 's/VERSION_ID=//' \
+              -e 's/"//g' \
+              -e 's/\.//'`
+            os=$os$version
+        fi
+ 
+        if [[ $os == rhel7* && $RETCODE -eq 255 ]]; then
+            inform "Ignore the error while rereading partition table."
+        elif [[ $os == rhel8* && $RETCODE -eq 1 ]]; then
             inform "Ignore the error while rereading partition table."
         else
             printError "failed to set partition for RHCOS DASD device"


### PR DESCRIPTION
The error code of rereading partition table for fdasd command has been changes
it will be 255 in package s390utils-base-2.4.0-1.el7.s390x for rhel7
and 1 in package s390utils-base-2.6.0-28.el8.s390x for rhel8

will ignore the error based on os version