### PR TITLE
[master] get_fcp_pair_with_same_index

### DIFF
--- a/doc/source/zvmsdk.conf.sample
+++ b/doc/source/zvmsdk.conf.sample
@@ -46,7 +46,7 @@
 # the times retried.
 #     
 # This param is optional
-#softstop_interval=5
+#softstop_interval=10
 
 
 # 
@@ -57,10 +57,17 @@
 # of softstop, this will help.
 #     
 # This param is optional
-#softstop_timeout=60
+#softstop_timeout=120
 
 
 [image]
+
+# 
+# Default compress level for captured image.
+# 
+# This param is optional
+#default_compress_level=6
+
 
 # 
 # Directory to store sdk images.
@@ -200,6 +207,30 @@
 # 
 # This param is optional
 #fcp_list=
+
+
+# 
+# fcp pair selection algorithm
+# 
+# fcp_list example:
+# fa00-fa02; fb00-fb02
+# 
+# If use get_fcp_pair_with_same_index,
+# then fcp pair is randomly selected from below combinations.
+# [fa00,fb00],[fa01,fb01],[fa02,fb02]
+# 
+# If use get_fcp_pair,
+# then fcp pair is randomly selected from below combinations.
+# [fa00,fb00],[fa01,fb00],[fa02,fb00]
+# [fa00,fb01],[fa01,fb01],[fa02,fb01]
+# [fa00,fb02],[fa01,fb02],[fa02,fb02]
+# 
+# Possible value:
+# 0 : use get_fcp_pair. this is the default
+# 1 : use get_fcp_pair_with_same_index
+# 
+# This param is optional
+#get_fcp_pair_with_same_index=0
 
 
 [wsgi]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+nose
 mock>=2.0.0 # BSD
 PyYAML>=3.10
 python-subunit>=1.0.0 # Apache-2.0/BSD

--- a/zvmsdk/config.py
+++ b/zvmsdk/config.py
@@ -443,7 +443,33 @@ running SDK is able to read write and execute the directory.
 volume fcp list.
 
 SDK will only use the fcp devices in the scope of this value.
-'''),
+'''
+        ),
+    Opt('get_fcp_pair_with_same_index',
+        section='volume',
+        default='0',
+        opt_type='int',
+        help='''
+fcp pair selection algorithm
+
+fcp_list example:
+fa00-fa02; fb00-fb02
+
+If use get_fcp_pair_with_same_index,
+then fcp pair is randomly selected from below combinations.
+[fa00,fb00],[fa01,fb01],[fa02,fb02]
+
+If use get_fcp_pair,
+then fcp pair is randomly selected from below combinations.
+[fa00,fb00],[fa01,fb00],[fa02,fb00]
+[fa00,fb01],[fa01,fb01],[fa02,fb01]
+[fa00,fb02],[fa01,fb02],[fa02,fb02]
+
+Possible value:
+0 : use get_fcp_pair. this is the default
+1 : use get_fcp_pair_with_same_index
+'''
+      ),
     # tests options
     Opt('images',
         section='tests',

--- a/zvmsdk/tests/unit/test_database.py
+++ b/zvmsdk/tests/unit/test_database.py
@@ -429,17 +429,64 @@ class FCPDbOperatorTestCase(base.SDKTestCase):
         finally:
             self.db_op.delete('1111')
 
-    def test_get_fcp_pair(self):
-        self.db_op.new('1111', 0)
-        self.db_op.new('1112', 1)
-        self.db_op.new('1113', 2)
+    def test_get_fcp_pair_with_same_index(self):
+        '''
+        get_fcp_pair_with_same_index() only returns
+        two possible values:
+        case 1
+           randomly choose a pair of below combinations:
+           [1a00,1b00] ,[1a01,1b01] ,[1a02,1b02]...
+           rather than below combinations:
+           [1a00,1b02] ,[1a03,1b00]
+           [1a02], [1b03]
+        case 2
+           an empty list(i.e. [])
+           if no expected pair found
+        '''
         try:
-            fcp_list = self.db_op.get_fcp_pair()
-            self.assertEqual(fcp_list, [u'1111', u'1112', '1113'])
+            # test case1
+            self.db_op.new('1a00', 0)
+            self.db_op.new('1a01', 0)
+            self.db_op.new('1a02', 0)
+            self.db_op.new('1a03', 0)
+            self.db_op.new('1a04', 0)
+            self.db_op.new('1a05', 0)
+            self.db_op.new('1b00', 1)
+            self.db_op.new('1b01', 1)
+            self.db_op.new('1b02', 1)
+            self.db_op.new('1b03', 1)
+            self.db_op.new('1b04', 1)
+            self.db_op.increase_usage('1a00')
+            self.db_op.increase_usage('1a00')
+            self.db_op.increase_usage('1a02')
+            self.db_op.increase_usage('1b04')
+            self.db_op.reserve('1a02')
+            self.db_op.reserve('1a04')
+            self.db_op.reserve('1b00')
+            expected_pairs_1 = [['1a01', '1b01'], ['1a03', '1b03']]
+            for i in range(10):
+                fcp_list = self.db_op.get_fcp_pair_with_same_index()
+                self.assertIn(fcp_list, expected_pairs_1)
+            # test case2
+            self.db_op.reserve('1a01')
+            self.db_op.reserve('1b01')
+            self.db_op.reserve('1a03')
+            self.db_op.reserve('1b03')
+            expected_pairs_2 = []
+            fcp_list = self.db_op.get_fcp_pair_with_same_index()
+            self.assertEqual(fcp_list, expected_pairs_2)
         finally:
-            self.db_op.delete('1111')
-            self.db_op.delete('1112')
-            self.db_op.delete('1113')
+            self.db_op.delete('1a00')
+            self.db_op.delete('1a01')
+            self.db_op.delete('1a02')
+            self.db_op.delete('1a03')
+            self.db_op.delete('1a04')
+            self.db_op.delete('1a05')
+            self.db_op.delete('1b00')
+            self.db_op.delete('1b01')
+            self.db_op.delete('1b02')
+            self.db_op.delete('1b03')
+            self.db_op.delete('1b04')
 
     def test_find_and_reserve(self):
         self.db_op.new('1111', 1)

--- a/zvmsdk/volumeop.py
+++ b/zvmsdk/volumeop.py
@@ -514,7 +514,22 @@ class FCPManager(object):
         # get the FCP devices belongs to assigner_id
         fcp_list = self.db.get_from_assigner(assigner_id)
         if not fcp_list:
-            free_unreserved = self.db.get_fcp_pair()
+            if CONF.volume.get_fcp_pair_with_same_index:
+                '''
+                If use get_fcp_pair_with_same_index,
+                then fcp pair is randomly selected from below combinations.
+                [fa00,fb00],[fa01,fb01],[fa02,fb02]
+                '''
+                free_unreserved = self.db.get_fcp_pair_with_same_index()
+            else:
+                '''
+                If use get_fcp_pair,
+                then fcp pair is randomly selected from below combinations.
+                [fa00,fb00],[fa01,fb00],[fa02,fb00]
+                [fa00,fb01],[fa01,fb01],[fa02,fb01]
+                [fa00,fb02],[fa01,fb02],[fa02,fb02]
+                '''
+                free_unreserved = self.db.get_fcp_pair()
             for item in free_unreserved:
                 available_list.append(item)
                 # record the assigner id in the fcp so that


### PR DESCRIPTION
https://github.ibm.com/zvc/planning/issues/3343

1.add another fcp pair selection algorithm
2.add a switch in zvmsdk.conf to switch between below two algo
* get_fcp_pair_with_same_index << added by this PR
* get_fcp_pair

Signed-off-by: Da Long Wang <shdlwang@cn.ibm.com>