### PR TITLE
Get console output error due to python upgrade

### DIFF
--- a/zvmsdk/vmops.py
+++ b/zvmsdk/vmops.py
@@ -372,6 +372,7 @@ class VMOps(object):
         log_fp = open(log_path, 'rb')
         try:
             log_data, remaining = zvmutils.last_bytes(log_fp, log_size)
+            log_data = bytes.decode(log_data)
         except Exception as err:
             msg = ("Failed to truncate console log, error: %s" %
                    six.text_type(err))


### PR DESCRIPTION
The get console output failed due to python upgrade,
need to decode bytes in zvmsdk

Signed-off-by: ylpan <ylpan@cn.ibm.com>