### PR TITLE
ignore 596/6831 in delete action

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -2104,9 +2104,15 @@ class SMTClient(object):
                 # guest vm definition not found
                 LOG.debug("The guest %s does not exist." % userid)
                 return
-            else:
-                msg = "SMT error: %s" % err.format_message()
-                raise exception.SDKSMTRequestFailed(err.results, msg)
+
+            # ingore delete VM not finished error
+            if err.results['rc'] == 596 and err.results['rs'] == 6831:
+                # 596/6831 means delete VM not finished yet
+                LOG.warning("The guest %s deleted with 596/6831" % userid)
+                return
+
+            msg = "SMT error: %s" % err.format_message()
+            raise exception.SDKSMTRequestFailed(err.results, msg)
 
     def delete_vm(self, userid):
         self.delete_userid(userid)

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1574,6 +1574,15 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         request.assert_called_once_with(rd)
 
     @mock.patch.object(smtclient.SMTClient, '_request')
+    def test_delete_userid_too_slow(self, request):
+        rd = 'deletevm fuser1 directory'
+        results = {'rc': 596, 'rs': 6831, 'logEntries': ''}
+        request.side_effect = exception.SDKSMTRequestFailed(results,
+                                                               "fake error")
+        self._smtclient.delete_userid('fuser1')
+        request.assert_called_once_with(rd)
+
+    @mock.patch.object(smtclient.SMTClient, '_request')
     def test_delete_userid_failed(self, request):
         rd = 'deletevm fuser1 directory'
         results = {'rc': 400, 'rs': 104, 'logEntries': ''}


### PR DESCRIPTION
596/6831 is really annoying error in DIRMAINT
we need handle it at upper layer to avoid report `false alarm` 