### PR TITLE
cleanup namelist after userid deleted

### DIFF
--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -2117,6 +2117,9 @@ class SMTClient(object):
     def delete_vm(self, userid):
         self.delete_userid(userid)
 
+        # remove userid from smapi namelist
+        self.namelist_remove(zvmutils.get_namelist(), userid)
+
         # revoke userid from vswitch
         action = "revoke id %s authority from vswitch" % userid
         with zvmutils.log_and_reraise_sdkbase_error(action):

--- a/zvmsdk/tests/unit/test_vmops.py
+++ b/zvmsdk/tests/unit/test_vmops.py
@@ -211,13 +211,11 @@ class SDKVMOpsTestCase(base.SDKTestCase):
         self.vmops.get_definition_info("fake_user_id", nic_coupled='1000')
         get_user_direct.assert_called_with("fake_user_id")
 
-    @mock.patch("zvmsdk.smtclient.SMTClient.namelist_remove")
     @mock.patch("zvmsdk.smtclient.SMTClient.delete_vm")
-    def test_delete_vm(self, delete_vm, namelistremove):
+    def test_delete_vm(self, delete_vm):
         userid = 'userid'
         self.vmops.delete_vm(userid)
         delete_vm.assert_called_once_with(userid)
-        namelistremove.assert_called_once_with('TSTNLIST', userid)
 
     @mock.patch("zvmsdk.smtclient.SMTClient.execute_cmd")
     def test_execute_cmd(self, execute_cmd):

--- a/zvmsdk/vmops.py
+++ b/zvmsdk/vmops.py
@@ -258,9 +258,6 @@ class VMOps(object):
         """Delete z/VM userid for the instance."""
         LOG.info("Begin to delete vm %s", userid)
         self._smtclient.delete_vm(userid)
-
-        # remove userid from smapi namelist
-        self._smtclient.namelist_remove(self._namelist, userid)
         LOG.info("Complete delete vm %s", userid)
 
     def execute_cmd(self, userid, cmdStr):


### PR DESCRIPTION
Fix the problem that userid has beed deleted successfully but it
remain included in smapi namelist.

The root cause is exception raised when cleanup database records
and revoke access. In this change, will remove the userid from
smapi namelist immediately after it successfully deleted.

Signed-off-by: bjhuangr <bjhuangr@cn.ibm.com>