### PR TITLE
re-use previous IUCV authorized userid

### DIFF
--- a/zthin-parts/zthin/include/IUCV/iucvclient.h
+++ b/zthin-parts/zthin/include/IUCV/iucvclient.h
@@ -46,6 +46,7 @@
 #define FILE_SENT_OVER "FILE_SENT_OVER"
 #define FILE_PATH_IUCV_SERVER "/opt/zthin/bin/IUCV/iucvserv"
 #define FILE_PATH_IUCV_FOLDER "/opt/zthin/bin/IUCV"
+#define FILE_PATH_IUCV_AUTH_USERID "/etc/zvmsdk/iucv_authorized_userid"
 #define IUCV_SERVER_NEED_UPGRADE "need_upgrade"
 #define UPGRADE_NEEDED_SYSTEMD "UPGRADE_NEEDED_SYSTEMD"
 #define UPGRADE_NEEDED_SYSTEMV "UPGRADE_NEEDED_SYSTEMV"

--- a/zvmsdk/constants.py
+++ b/zvmsdk/constants.py
@@ -136,3 +136,4 @@ FILE_TYPE = {
     'EXPORT': 'exported'}
 
 SDK_DATA_PATH = '/var/lib/zvmsdk/'
+IUCV_AUTH_USERID_PATH = '/etc/zvmsdk/iucv_authorized_userid'

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -691,7 +691,6 @@ class SMTClient(object):
         :param str guest: the user id of the vm
         :param str client: the user id of the client that can communicate to
                guest using IUCV"""
-
         client = client or zvmutils.get_smt_userid()
 
         iucv_path = "/tmp/" + userid
@@ -836,7 +835,13 @@ class SMTClient(object):
                 # remove the local temp config drive folder
                 self._pathutils.clean_temp_folder(tmp_trans_dir)
         # Authorize iucv client
-        self.guest_authorize_iucv_client(userid)
+        client_id = None
+        # try to re-use previous iucv authorized userid at first
+        if os.path.exists(const.IUCV_AUTH_USERID_PATH):
+            LOG.debug("Re-use previous iucv authorized userid")
+            with open(const.IUCV_AUTH_USERID_PATH) as f:
+                client_id = f.read().strip()
+        self.guest_authorize_iucv_client(userid, client_id)
         # Update os version in guest metadata
         # TODO: may should append to old metadata, not replace
         if skipdiskcopy:

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -324,7 +324,7 @@ class SDKSMTClientTestCases(base.SDKTestCase):
         request.assert_has_calls([mock.call(purge_rd), mock.call(punch_rd)])
         mkdtemp.assert_called_with()
         cleantemp.assert_called_with('/tmp/tmpdir')
-        guestauth.assert_called_once_with(userid)
+        guestauth.assert_called_once_with(userid, None)
         guest_update.assert_called_once_with(userid, meta='os_version=fakeos')
 
     @mock.patch.object(database.GuestDbOperator, 'update_guest_by_userid')


### PR DESCRIPTION
If /etc/zvmsdk/iucv_authorized_userid file exists, will re-use the
userid when deploying new z/VM guests, and also re-use the userid
in iucv client.

Signed-off-by: bjhuangr <bjhuangr@cn.ibm.com>